### PR TITLE
Update for osg-htc

### DIFF
--- a/docs/network-troubleshooting.md
+++ b/docs/network-troubleshooting.md
@@ -38,7 +38,7 @@ This page contains information on opening ticket and pointers to relevant tools 
 
 **OSG**: If you have questions or unusual problems you think are OSG related, feel free to contact the OSG GOC. You can also open network related tickets and OSG can help to 'triage' your request and get it to the right people: 
 
--   <https://opensciencegrid.org/production/>
+-   <https://osg-htc.org/production/>
 
 **WLCG**: WLCG has a dedicated support unit, which will assist in debugging the problem and triaging the issue. More details can be found at:
 

--- a/docs/perfsonar/installation.md
+++ b/docs/perfsonar/installation.md
@@ -108,6 +108,6 @@ You might not be able to access the page if you are not properly registered in G
 
 Each *OSG site* should have two perfSONAR instances (one for Latency and one for Bandwidth) installed to enable network monitoring. These instances should be located as "close" (in a network-sense) as possible to the site's storage. If a logical site is comprised of more than one physical site, each physical site should be instrumented with perfSONAR instances.
 
-To add hosts to OSG Topology, please follow the instructions at https://opensciencegrid.org/docs/common/registration/
+To add hosts to OSG Topology, please follow the instructions at https://osg-htc.org/docs/common/registration/
 
 If you have problems or questions please consult our [FAQ](faq.md) or alternatively open a ticket with GOC. 


### PR DESCRIPTION
All opensciencegrid.org/** websites have been moved so this is the final clean up of existing pointers to the previous locations.

Another pass will be done in the future to clean up **.opensciencegrid.org subdomains when they are transferred.