### PR TITLE
Fix perfSONAR testpoint container restart on reboot

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,19 +1,52 @@
 # Ansible: perfSONAR Testpoint (Minimal Skeleton)
 
-This minimal Ansible skeleton installs and configures a perfSONAR testpoint on RHEL-family systems with optional features you can toggle:
+This minimal Ansible skeleton installs and configures perfSONAR testpoints on RHEL-family systems with optional features you can toggle:
 - fail2ban
 - SELinux
 - nftables
+
+It includes support for both bare-metal and containerized deployments:
+- **Bare-metal deployment**: Traditional perfSONAR testpoint package installation
+- **Container deployment**: Podman-compose based containerized testpoint with automatic restart
 
 It is designed to be small, idempotent, and easy to try. Extend as needed for your environment.
 
 ## Prerequisites
 - Control node with Ansible >= 2.12
 - Target host: RHEL/Alma/Rocky 8/9 (sudo privileges)
-- Network access to OS and perfSONAR repos
+- Network access to OS and perfSONAR repos (for bare-metal)
+- Network access to container registries (for containerized deployment)
 
 ## Inventory Example
 See [inventory.example](inventory.example). Place your target host(s) in the `testpoints` group.
+
+## Deployment Options
+
+### Container Deployment (Recommended)
+Deploy perfSONAR testpoint as containers with automatic restart on boot:
+
+```bash
+# Deploy container-based testpoint with systemd service
+ansible-playbook -i ansible/inventory.example ansible/playbooks/deploy-testpoint-container.yml
+```
+
+Features:
+- Installs podman and podman-compose
+- Deploys docker-compose.yml from upstream
+- Installs and enables systemd service for automatic restart on boot
+- Includes health checks and verification
+
+### Bare-metal Deployment (Traditional)
+Install perfSONAR testpoint packages directly on the host:
+
+```bash
+# Dry run
+ansible-playbook -i ansible/inventory.example ansible/site.yml --check
+
+# Apply with optional features enabled
+ansible-playbook -i ansible/inventory.example ansible/site.yml \
+  -e enable_fail2ban=true -e enable_selinux=true -e enable_nftables=true
+```
 
 ## Feature Toggles
 These booleans can be set in group_vars, host_vars, or via `-e` extra vars:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,28 +1,33 @@
 # Ansible: perfSONAR Testpoint (Minimal Skeleton)
 
 This minimal Ansible skeleton installs and configures perfSONAR testpoints on RHEL-family systems with optional features you can toggle:
+
 - fail2ban
 - SELinux
 - nftables
 
 It includes support for both bare-metal and containerized deployments:
+
 - **Bare-metal deployment**: Traditional perfSONAR testpoint package installation
 - **Container deployment**: Podman-compose based containerized testpoint with automatic restart
 
 It is designed to be small, idempotent, and easy to try. Extend as needed for your environment.
 
 ## Prerequisites
+
 - Control node with Ansible >= 2.12
 - Target host: RHEL/Alma/Rocky 8/9 (sudo privileges)
 - Network access to OS and perfSONAR repos (for bare-metal)
 - Network access to container registries (for containerized deployment)
 
 ## Inventory Example
+
 See [inventory.example](inventory.example). Place your target host(s) in the `testpoints` group.
 
 ## Deployment Options
 
 ### Container Deployment (Recommended)
+
 Deploy perfSONAR testpoint as containers with automatic restart on boot:
 
 ```bash
@@ -31,12 +36,14 @@ ansible-playbook -i ansible/inventory.example ansible/playbooks/deploy-testpoint
 ```
 
 Features:
+
 - Installs podman and podman-compose
 - Deploys docker-compose.yml from upstream
 - Installs and enables systemd service for automatic restart on boot
 - Includes health checks and verification
 
 ### Bare-metal Deployment (Traditional)
+
 Install perfSONAR testpoint packages directly on the host:
 
 ```bash
@@ -49,17 +56,21 @@ ansible-playbook -i ansible/inventory.example ansible/site.yml \
 ```
 
 ## Feature Toggles
+
 These booleans can be set in group_vars, host_vars, or via `-e` extra vars:
+
 - `enable_fail2ban` (default: false)
 - `enable_selinux`   (default: false)
 - `enable_nftables`  (default: false)
 
 Additional variables:
+
 - `selinux_state`: enforcing | permissive | disabled (default: enforcing when enabled)
 - `testpoint_sysctls`: list of sysctl name/value pairs (default provided)
 - `testpoint_services`: list of services to enable/start (default provided)
 
 ## Quick Start
+
 ```bash
 # Dry run
 ansible-playbook -i ansible/inventory.example ansible/site.yml --check
@@ -70,11 +81,13 @@ ansible-playbook -i ansible/inventory.example ansible/site.yml \
 ```
 
 ## Notes
+
 - nftables: This deploys a minimal ruleset to `/etc/nftables.conf` and enables the nftables service. If you already use another firewall (firewalld/iptables), test carefully and avoid conflicts.
 - SELinux: The role sets the SELinux mode only when `enable_selinux=true`. On systems without SELinux, the role is skipped.
 - Debian/Ubuntu: Not tested here. Tasks are guarded where practical; contributions welcome.
 
 ## Uninstall / Revert
+
 - Remove packages if desired and restore prior firewall configuration manually. This skeleton does not attempt to revert system-wide firewall configuration automatically.
 
 ## Replicating `install-perfsonar-testpoint.md` steps (opt-in)
@@ -87,28 +100,28 @@ passing extra-vars to the playbook.
 Key variables (role defaults in `ansible/roles/testpoint/defaults/main.yml`):
 
 - `perfsonar_install_tools_scripts` (bool, default: false)
-  - When true, the role will download the helper scripts into
-    `/opt/perfsonar-tp/tools_scripts` (from the `docs/perfsonar/tools_scripts` raw URLs)
+    - When true, the role will download the helper scripts into
+      `/opt/perfsonar-tp/tools_scripts` (from the `docs/perfsonar/tools_scripts` raw URLs)
 - `perfsonar_tools_root` (string, default: `/opt/perfsonar-tp`) - destination root
 - `perfsonar_run_check_deps` (bool, default: false) - run the `check-deps.sh` script
 - `perfsonar_pbr_action` (string, default: 'none') - one of: `none`, `generate`, `apply`, `rebuild`
 
 Examples:
 
-1) Bootstrap helper scripts only (no network changes):
+1. Bootstrap helper scripts only (no network changes):
 
 ```bash
 ansible-playbook -i ansible/inventory.example ansible/site.yml -e perfsonar_install_tools_scripts=true
 ```
 
-2) Bootstrap scripts and generate `/etc/perfSONAR-multi-nic-config.conf` (auto-detect):
+1. Bootstrap scripts and generate `/etc/perfSONAR-multi-nic-config.conf` (auto-detect):
 
 ```bash
 ansible-playbook -i ansible/inventory.example ansible/site.yml \
   -e perfsonar_install_tools_scripts=true -e perfsonar_pbr_action=generate
 ```
 
-3) Bootstrap scripts and apply in-place PBR changes (use with caution):
+1. Bootstrap scripts and apply in-place PBR changes (use with caution):
 
 ```bash
 ansible-playbook -i ansible/inventory.example ansible/site.yml \

--- a/ansible/playbooks/deploy-testpoint-container.yml
+++ b/ansible/playbooks/deploy-testpoint-container.yml
@@ -1,0 +1,102 @@
+---
+# Playbook: Deploy perfSONAR testpoint container with podman-compose
+# Installs required packages, deploys docker-compose.yml, and sets up
+# systemd service for automatic container restart on boot.
+
+- hosts: testpoints
+  become: true
+  vars:
+    perfsonar_install_dir: /opt/perfsonar-tp
+    perfsonar_compose_url: https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/docker-compose.yml
+    perfsonar_tools_install_url: https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install_tools_scripts.sh
+    perfsonar_systemd_install_url: https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install-systemd-service.sh
+    
+  tasks:
+    - name: Ensure system is up to date
+      package:
+        name: '*'
+        state: latest
+      tags: ['system', 'packages']
+
+    - name: Install required packages for podman-compose
+      package:
+        name:
+          - git
+          - podman
+          - podman-compose
+          - nftables
+          - iproute
+        state: present
+      tags: ['packages']
+
+    - name: Create perfSONAR installation directory
+      file:
+        path: "{{ perfsonar_install_dir }}"
+        state: directory
+        mode: '0755'
+      tags: ['deploy']
+
+    - name: Download and install tools_scripts
+      shell: |
+        curl -fsSL {{ perfsonar_tools_install_url }} -o /tmp/install_tools_scripts.sh
+        chmod +x /tmp/install_tools_scripts.sh
+        /tmp/install_tools_scripts.sh {{ perfsonar_install_dir }}
+        rm -f /tmp/install_tools_scripts.sh
+      args:
+        creates: "{{ perfsonar_install_dir }}/tools_scripts/README.md"
+      tags: ['deploy']
+
+    - name: Download docker-compose.yml
+      get_url:
+        url: "{{ perfsonar_compose_url }}"
+        dest: "{{ perfsonar_install_dir }}/docker-compose.yml"
+        mode: '0644'
+      tags: ['deploy']
+
+    - name: Create psconfig directory
+      file:
+        path: "{{ perfsonar_install_dir }}/psconfig"
+        state: directory
+        mode: '0755'
+      tags: ['deploy']
+
+    - name: Download and run systemd service installer
+      shell: |
+        curl -fsSL {{ perfsonar_systemd_install_url }} -o /tmp/install-systemd-service.sh
+        chmod +x /tmp/install-systemd-service.sh
+        /tmp/install-systemd-service.sh {{ perfsonar_install_dir }}
+        rm -f /tmp/install-systemd-service.sh
+      args:
+        creates: /etc/systemd/system/perfsonar-testpoint.service
+      tags: ['systemd']
+
+    - name: Ensure perfsonar-testpoint service is enabled
+      systemd:
+        name: perfsonar-testpoint
+        enabled: true
+        daemon_reload: true
+      tags: ['systemd']
+
+    - name: Start perfsonar-testpoint service
+      systemd:
+        name: perfsonar-testpoint
+        state: started
+      tags: ['systemd', 'start']
+
+    - name: Wait for containers to be healthy
+      shell: podman ps --filter "name=perfsonar-testpoint" --format "{{ '{{' }}.Status{{ '}}' }}"
+      register: container_status
+      until: "'Up' in container_status.stdout"
+      retries: 10
+      delay: 10
+      tags: ['verify']
+
+    - name: Display container status
+      command: podman ps
+      register: podman_ps
+      tags: ['verify']
+
+    - name: Show running containers
+      debug:
+        var: podman_ps.stdout_lines
+      tags: ['verify']

--- a/docs/perfsonar/CONTAINER_RESTART_ISSUE.md
+++ b/docs/perfsonar/CONTAINER_RESTART_ISSUE.md
@@ -1,0 +1,85 @@
+# perfSONAR Testpoint Container Restart Loop Issue
+
+## Problem Description
+
+The perfSONAR testpoint container enters a restart loop when using certain docker-compose.yml configurations. The container continuously restarts and fails to initialize systemd properly.
+
+## Root Cause
+
+The issue occurs when the docker-compose.yml file is configured with:
+- `privileged: true`
+- `cgroupns: private`
+- **Missing** `/sys/fs/cgroup:/sys/fs/cgroup:rw` volume mount
+
+The systemd process inside the container requires proper cgroup access to function. Without the cgroup volume mount, systemd cannot initialize properly, causing the container to fail and restart repeatedly.
+
+## Solution
+
+Use the recommended docker-compose.yml configuration from the repository which includes:
+
+```yaml
+services:
+  testpoint:
+    container_name: perfsonar-testpoint
+    image: hub.opensciencegrid.org/osg-htc/perfsonar-testpoint:production
+    network_mode: "host"
+    cgroup: host  # Use cgroup: host instead of cgroupns: private
+    environment:
+      - TZ=UTC
+    restart: unless-stopped
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw  # REQUIRED for systemd
+      - /opt/perfsonar-tp/psconfig:/etc/perfsonar/psconfig:Z
+      - /var/www/html:/var/www/html:z
+      - /etc/apache2:/etc/apache2:z
+      - /etc/letsencrypt:/etc/letsencrypt:z
+    tty: true
+    pids_limit: 8192
+    cap_add:
+      - CAP_NET_RAW
+    labels:
+      - io.containers.autoupdate=registry
+```
+
+## Fixing Existing Deployments
+
+If you have an existing deployment with the restart loop issue:
+
+1. Stop the containers:
+   ```bash
+   cd /opt/perfsonar-tp
+   podman-compose down
+   ```
+
+2. Update the docker-compose.yml file to use the recommended configuration from:
+   ```bash
+   curl -fsSL \
+       https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/docker-compose.yml \
+       -o /opt/perfsonar-tp/docker-compose.yml
+   ```
+
+3. Restart the service:
+   ```bash
+   systemctl restart perfsonar-testpoint
+   ```
+
+## Verification
+
+Check that containers are running properly:
+
+```bash
+podman ps
+systemctl status perfsonar-testpoint
+```
+
+The perfsonar-testpoint container should show status "Up" and not be restarting.
+
+## Related Files
+
+- Recommended compose file: `docs/perfsonar/tools_scripts/docker-compose.yml`
+- Systemd service installer: `docs/perfsonar/tools_scripts/install-systemd-service.sh`
+- Installation guide: `docs/perfsonar/install-testpoint.md`

--- a/docs/perfsonar/CONTAINER_RESTART_ISSUE.md
+++ b/docs/perfsonar/CONTAINER_RESTART_ISSUE.md
@@ -7,6 +7,7 @@ The perfSONAR testpoint container enters a restart loop when using certain docke
 ## Root Cause
 
 The issue occurs when the docker-compose.yml file is configured with:
+
 - `privileged: true`
 - `cgroupns: private`
 - **Missing** `/sys/fs/cgroup:/sys/fs/cgroup:rw` volume mount
@@ -50,19 +51,22 @@ services:
 If you have an existing deployment with the restart loop issue:
 
 1. Stop the containers:
+
    ```bash
    cd /opt/perfsonar-tp
    podman-compose down
    ```
 
-2. Update the docker-compose.yml file to use the recommended configuration from:
+1. Update the docker-compose.yml file to use the recommended configuration from:
+
    ```bash
    curl -fsSL \
        https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/docker-compose.yml \
        -o /opt/perfsonar-tp/docker-compose.yml
    ```
 
-3. Restart the service:
+1. Restart the service:
+
    ```bash
    systemctl restart perfsonar-testpoint
    ```

--- a/docs/perfsonar/FIX_SUMMARY.md
+++ b/docs/perfsonar/FIX_SUMMARY.md
@@ -1,0 +1,146 @@
+# perfSONAR Testpoint Container Restart Fix - Summary
+
+## Problem
+After a host reboot, podman-compose containers for perfSONAR testpoint did not restart automatically because there was no systemd service to manage them. Additionally, the deployed docker-compose.yml configuration had issues that caused the testpoint container to enter a restart loop.
+
+## Solutions Implemented
+
+### 1. Created Systemd Service for Automatic Restart
+**File**: `/etc/systemd/system/perfsonar-testpoint.service`
+
+A systemd service unit was created to manage the podman-compose containers and ensure they start automatically on boot.
+
+**Key features**:
+- Type: oneshot with RemainAfterExit
+- Starts after network-online.target
+- Runs `podman-compose up -d` on start
+- Runs `podman-compose down` on stop
+- Automatic restart on failure
+- Enabled by default to start on boot
+
+**Status**: Service is now installed, enabled, and running successfully on `/opt/perfsonar-tp`.
+
+### 2. Fixed Container Configuration Issue
+**File**: `/opt/perfsonar-tp/docker-compose.yml`
+
+Updated the docker-compose.yml to use the recommended configuration:
+- Changed from `cgroupns: private` to `cgroup: host`
+- Added required `/sys/fs/cgroup:/sys/fs/cgroup:rw` volume mount
+- Added `tty: true` for proper terminal handling
+- Removed custom entrypoint wrapper that was causing initialization issues
+
+**Result**: Containers now start properly without entering a restart loop.
+
+### 3. Created Helper Script
+**File**: `docs/perfsonar/tools_scripts/install-systemd-service.sh`
+
+A new helper script automates the installation and configuration of the systemd service.
+
+**Features**:
+- Root privilege check
+- Validates podman-compose is installed
+- Validates installation directory exists
+- Creates systemd service file
+- Reloads systemd and enables service
+- Supports custom installation paths
+- Provides helpful usage examples
+
+**Usage**:
+```bash
+sudo bash install-systemd-service.sh [/opt/perfsonar-tp]
+```
+
+### 4. Updated Documentation
+**Files Updated**:
+- `docs/perfsonar/install-testpoint.md` - Added section on enabling automatic restart
+- `docs/perfsonar/tools_scripts/README.md` - Added systemd service installer documentation
+- `docs/perfsonar/CONTAINER_RESTART_ISSUE.md` - New troubleshooting guide for container restart issues
+
+**Key additions**:
+- Instructions for installing systemd service (manual and automated)
+- Useful systemctl commands for managing the service
+- Explanation of why systemd service is needed
+- Troubleshooting guidance
+
+### 5. Created Ansible Playbook
+**File**: `ansible/playbooks/deploy-testpoint-container.yml`
+
+A complete Ansible playbook for automated deployment of perfSONAR testpoint containers.
+
+**Features**:
+- Installs required packages (podman, podman-compose, etc.)
+- Downloads and installs tools_scripts
+- Deploys docker-compose.yml
+- Installs and enables systemd service
+- Verifies containers are running
+- Includes health checks
+
+**Also updated**: `ansible/README.md` with deployment options and usage examples.
+
+## Files Modified in Repository
+
+### New Files Created:
+1. `docs/perfsonar/tools_scripts/install-systemd-service.sh` - Systemd service installer
+2. `ansible/playbooks/deploy-testpoint-container.yml` - Ansible deployment playbook
+3. `docs/perfsonar/CONTAINER_RESTART_ISSUE.md` - Troubleshooting guide
+
+### Files Updated:
+1. `docs/perfsonar/install-testpoint.md` - Added automatic restart section
+2. `docs/perfsonar/tools_scripts/README.md` - Added systemd service documentation
+3. `ansible/README.md` - Added container deployment section
+
+## Testing and Verification
+
+### Local System (/opt/perfsonar-tp)
+✅ Systemd service created and enabled
+✅ Containers starting successfully
+✅ perfSONAR testpoint responding on https://localhost/
+✅ Service will survive reboots (enabled in systemd)
+
+### Verification Commands:
+```bash
+# Check service status
+systemctl status perfsonar-testpoint
+
+# Check containers
+podman ps
+
+# Test web interface
+curl -kSfI https://localhost/
+
+# View service logs
+journalctl -u perfsonar-testpoint -f
+```
+
+## Next Steps for Deployment
+
+To apply these fixes to other perfSONAR testpoint deployments:
+
+1. **Manual deployment**:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install-systemd-service.sh \
+       -o /tmp/install-systemd-service.sh
+   sudo bash /tmp/install-systemd-service.sh /opt/perfsonar-tp
+   ```
+
+2. **Automated deployment with Ansible**:
+   ```bash
+   ansible-playbook -i inventory ansible/playbooks/deploy-testpoint-container.yml
+   ```
+
+3. **Fix existing deployments with restart issues**:
+   - Update docker-compose.yml to recommended configuration
+   - Restart the perfsonar-testpoint service
+
+## Benefits
+
+✅ **Automatic restart after reboot** - Containers will always start when the host boots
+✅ **Service management** - Standard systemctl commands for start/stop/restart
+✅ **Logging** - Centralized logs via journalctl
+✅ **Reliability** - Automatic restart on failure
+✅ **Automation** - Ansible playbook for consistent deployments
+✅ **Documentation** - Clear instructions for users
+
+## Conclusion
+
+The perfSONAR testpoint container restart issue has been fully resolved. The systemd service is now managing the containers, ensuring they restart automatically after host reboots. Documentation and automation scripts have been updated to help others implement this fix easily.

--- a/docs/perfsonar/FIX_SUMMARY.md
+++ b/docs/perfsonar/FIX_SUMMARY.md
@@ -1,16 +1,19 @@
 # perfSONAR Testpoint Container Restart Fix - Summary
 
 ## Problem
+
 After a host reboot, podman-compose containers for perfSONAR testpoint did not restart automatically because there was no systemd service to manage them. Additionally, the deployed docker-compose.yml configuration had issues that caused the testpoint container to enter a restart loop.
 
 ## Solutions Implemented
 
 ### 1. Created Systemd Service for Automatic Restart
+
 **File**: `/etc/systemd/system/perfsonar-testpoint.service`
 
 A systemd service unit was created to manage the podman-compose containers and ensure they start automatically on boot.
 
 **Key features**:
+
 - Type: oneshot with RemainAfterExit
 - Starts after network-online.target
 - Runs `podman-compose up -d` on start
@@ -21,9 +24,11 @@ A systemd service unit was created to manage the podman-compose containers and e
 **Status**: Service is now installed, enabled, and running successfully on `/opt/perfsonar-tp`.
 
 ### 2. Fixed Container Configuration Issue
+
 **File**: `/opt/perfsonar-tp/docker-compose.yml`
 
 Updated the docker-compose.yml to use the recommended configuration:
+
 - Changed from `cgroupns: private` to `cgroup: host`
 - Added required `/sys/fs/cgroup:/sys/fs/cgroup:rw` volume mount
 - Added `tty: true` for proper terminal handling
@@ -32,11 +37,13 @@ Updated the docker-compose.yml to use the recommended configuration:
 **Result**: Containers now start properly without entering a restart loop.
 
 ### 3. Created Helper Script
+
 **File**: `docs/perfsonar/tools_scripts/install-systemd-service.sh`
 
 A new helper script automates the installation and configuration of the systemd service.
 
 **Features**:
+
 - Root privilege check
 - Validates podman-compose is installed
 - Validates installation directory exists
@@ -46,28 +53,34 @@ A new helper script automates the installation and configuration of the systemd 
 - Provides helpful usage examples
 
 **Usage**:
+
 ```bash
 sudo bash install-systemd-service.sh [/opt/perfsonar-tp]
 ```
 
 ### 4. Updated Documentation
+
 **Files Updated**:
+
 - `docs/perfsonar/install-testpoint.md` - Added section on enabling automatic restart
 - `docs/perfsonar/tools_scripts/README.md` - Added systemd service installer documentation
 - `docs/perfsonar/CONTAINER_RESTART_ISSUE.md` - New troubleshooting guide for container restart issues
 
 **Key additions**:
+
 - Instructions for installing systemd service (manual and automated)
 - Useful systemctl commands for managing the service
 - Explanation of why systemd service is needed
 - Troubleshooting guidance
 
 ### 5. Created Ansible Playbook
+
 **File**: `ansible/playbooks/deploy-testpoint-container.yml`
 
 A complete Ansible playbook for automated deployment of perfSONAR testpoint containers.
 
 **Features**:
+
 - Installs required packages (podman, podman-compose, etc.)
 - Downloads and installs tools_scripts
 - Deploys docker-compose.yml
@@ -79,25 +92,29 @@ A complete Ansible playbook for automated deployment of perfSONAR testpoint cont
 
 ## Files Modified in Repository
 
-### New Files Created:
-1. `docs/perfsonar/tools_scripts/install-systemd-service.sh` - Systemd service installer
-2. `ansible/playbooks/deploy-testpoint-container.yml` - Ansible deployment playbook
-3. `docs/perfsonar/CONTAINER_RESTART_ISSUE.md` - Troubleshooting guide
+### New Files Created
 
-### Files Updated:
+1. `docs/perfsonar/tools_scripts/install-systemd-service.sh` - Systemd service installer
+1. `ansible/playbooks/deploy-testpoint-container.yml` - Ansible deployment playbook
+1. `docs/perfsonar/CONTAINER_RESTART_ISSUE.md` - Troubleshooting guide
+
+### Files Updated
+
 1. `docs/perfsonar/install-testpoint.md` - Added automatic restart section
-2. `docs/perfsonar/tools_scripts/README.md` - Added systemd service documentation
-3. `ansible/README.md` - Added container deployment section
+1. `docs/perfsonar/tools_scripts/README.md` - Added systemd service documentation
+1. `ansible/README.md` - Added container deployment section
 
 ## Testing and Verification
 
 ### Local System (/opt/perfsonar-tp)
+
 ✅ Systemd service created and enabled
 ✅ Containers starting successfully
-✅ perfSONAR testpoint responding on https://localhost/
+✅ perfSONAR testpoint responding on <https://localhost/>
 ✅ Service will survive reboots (enabled in systemd)
 
-### Verification Commands:
+### Verification Commands
+
 ```bash
 # Check service status
 systemctl status perfsonar-testpoint
@@ -117,18 +134,20 @@ journalctl -u perfsonar-testpoint -f
 To apply these fixes to other perfSONAR testpoint deployments:
 
 1. **Manual deployment**:
+
    ```bash
    curl -fsSL https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install-systemd-service.sh \
        -o /tmp/install-systemd-service.sh
    sudo bash /tmp/install-systemd-service.sh /opt/perfsonar-tp
    ```
 
-2. **Automated deployment with Ansible**:
+1. **Automated deployment with Ansible**:
+
    ```bash
    ansible-playbook -i inventory ansible/playbooks/deploy-testpoint-container.yml
    ```
 
-3. **Fix existing deployments with restart issues**:
+1. **Fix existing deployments with restart issues**:
    - Update docker-compose.yml to recommended configuration
    - Restart the perfsonar-testpoint service
 

--- a/docs/perfsonar/install-testpoint.md
+++ b/docs/perfsonar/install-testpoint.md
@@ -154,8 +154,8 @@ If you prefer to configure rules manually, see the example below.
 
 Suppose:
 
-* eth0 is for latency tests, IP \= 192.168.10.10/24, GW \= 192.168.10.1
-* eth1 is for throughput tests, IP \= 10.20.30.10/24, GW \= 10.20.30.1
+- eth0 is for latency tests, IP \= 192.168.10.10/24, GW \= 192.168.10.1
+- eth1 is for throughput tests, IP \= 10.20.30.10/24, GW \= 10.20.30.1
 
 #### a) Add custom routing tables
 
@@ -224,9 +224,9 @@ The script writes rules to /etc/nftables.d/perfsonar.nft and logs to /var/log/pe
 
 Below is a sample NFTables rule set that
 
-* Allows required perfSONAR measurement ports (especially for testpoint: traceroute, iperf3, OWAMP, etc.)
-* Restricts SSH access to trusted subnets/hosts
-* Accepts ICMP/ICMPv6 and related/permitted connections
+- Allows required perfSONAR measurement ports (especially for testpoint: traceroute, iperf3, OWAMP, etc.)
+- Restricts SSH access to trusted subnets/hosts
+- Accepts ICMP/ICMPv6 and related/permitted connections
 
 /etc/nftables.conf:
 
@@ -321,7 +321,7 @@ podman exec -it perfsonar-testpoint psconfig remote --configure-archives add "ht
 
 ## 8. References & Further Reading
 
-* [perfSONAR testpoint Docker GitHub](https://github.com/perfsonar/perfsonar-testpoint-docker/)
-* [perfSONAR Documentation](https://docs.perfsonar.net/)
-* Red Hat Policy Routing [BROKEN-LINK: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_configuring-policy-based-routing_configuring-and-managing-networking]
-* [NFTables Wiki](https://wiki.nftables.org/)
+- [perfSONAR testpoint Docker GitHub](https://github.com/perfsonar/perfsonar-testpoint-docker/)
+- [perfSONAR Documentation](https://docs.perfsonar.net/)
+- Red Hat Policy Routing [BROKEN-LINK: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_configuring-policy-based-routing_configuring-and-managing-networking]
+- [NFTables Wiki](https://wiki.nftables.org/)

--- a/docs/perfsonar/install-testpoint.md
+++ b/docs/perfsonar/install-testpoint.md
@@ -107,6 +107,7 @@ sudo systemctl enable perfsonar-testpoint.service
 ```
 
 Useful commands:
+
 - Start service: `systemctl start perfsonar-testpoint`
 - Stop service: `systemctl stop perfsonar-testpoint`
 - Restart service: `systemctl restart perfsonar-testpoint`
@@ -324,4 +325,3 @@ podman exec -it perfsonar-testpoint psconfig remote --configure-archives add "ht
 * [perfSONAR Documentation](https://docs.perfsonar.net/)
 * Red Hat Policy Routing [BROKEN-LINK: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_configuring-policy-based-routing_configuring-and-managing-networking]
 * [NFTables Wiki](https://wiki.nftables.org/)
-

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -7,12 +7,14 @@ static IPv4/IPv6 addressing and per-NIC source-based routing via NetworkManager
 
 Quick overview
 --------------
+
 - Script: `perfSONAR-pbr-nm.sh`
 - Config file: `/etc/perfSONAR-multi-nic-config.conf`
 - Log file: `/var/log/perfSONAR-multi-nic-config.log`
 
 Install helper
 --------------
+
 A small helper is provided to populate `/opt/perfsonar-tp/tools_scripts` from
 this repository using a shallow sparse checkout. It copies only the
 `docs/perfsonar/tools_scripts` directory and preserves executable bits.
@@ -23,6 +25,7 @@ this repository using a shallow sparse checkout. It copies only the
 
 Systemd service installer
 --------------------------
+
 A helper script is provided to install and enable a systemd service for
 automatic container restart on boot. This ensures perfSONAR testpoint containers
 managed by podman-compose restart automatically after a host reboot.
@@ -43,6 +46,7 @@ sudo bash install-systemd-service.sh /custom/path/to/perfsonar-tp
 ```
 
 After installation:
+
 - Containers will automatically start on boot
 - Use `systemctl start|stop|restart|status perfsonar-testpoint` to manage
 - View logs with `journalctl -u perfsonar-testpoint -f`
@@ -71,6 +75,7 @@ bash docs/perfsonar/tools_scripts/install_tools_scripts.sh --skip-testpoint
 
 Requirements
 ------------
+
 - Must be run as root. The script now enforces running as root early in
   execution and will exit if run as a non-privileged user. Run it with sudo
   or from a root shell.
@@ -135,6 +140,7 @@ installing `rsync` provides safer, more robust backups.
 
 Safety first
 ------------
+
 This script will REMOVE ALL existing NetworkManager connections when run.
 Always test in a VM or console-attached host and use `--dry-run` to preview
 changes. The script creates a timestamped backup of existing connections before
@@ -188,12 +194,12 @@ Gateway requirement, inference, and generator warnings
 
 - Any NIC with an IPv4 address must have a corresponding IPv4 gateway; likewise for IPv6.
 - Conservative gateway inference: if a NIC has an address/prefix but no gateway, the tool will try to reuse a gateway from another NIC on the SAME subnet.
-  - IPv4: subnets are checked in bash; one unambiguous match is required.
-  - IPv6: requires `python3` (`ipaddress` module) to verify the gateway is in the same prefix; link-local gateways (fe80::/10) are not reused; one unambiguous match is required.
-  - If multiple gateways match, no guess is made; a warning is logged and validation will require you to set it explicitly.
+    - IPv4: subnets are checked in bash; one unambiguous match is required.
+    - IPv6: requires `python3` (`ipaddress` module) to verify the gateway is in the same prefix; link-local gateways (fe80::/10) are not reused; one unambiguous match is required.
+    - If multiple gateways match, no guess is made; a warning is logged and validation will require you to set it explicitly.
 - This inference runs in two places:
-  1) During auto-generation (`--generate-config-auto` or `--generate-config-debug`) so the written config can be immediately useful.
-  2) During normal execution after loading the config but before validation, so missing gateways may be filled automatically.
+    1. During auto-generation (`--generate-config-auto` or `--generate-config-debug`) so the written config can be immediately useful.
+    1. During normal execution after loading the config but before validation, so missing gateways may be filled automatically.
 
 Example: generated config with inferred gateways
 
@@ -238,7 +244,6 @@ Backups and safety
 ------------------
 
 - Before applying changes, the script creates a timestamped backup of existing NetworkManager connections. It prefers `rsync` when available and falls back to `cp -a`. If the backup fails, the script aborts without removing existing configurations.
-
 
 Tests
 -----

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -21,6 +21,32 @@ this repository using a shallow sparse checkout. It copies only the
 - Purpose: idempotent installer for `/opt/perfsonar-tp/tools_scripts`
 - Options: `--dry-run` (preview), `--skip-testpoint` (don't clone testpoint repo)
 
+Systemd service installer
+--------------------------
+A helper script is provided to install and enable a systemd service for
+automatic container restart on boot. This ensures perfSONAR testpoint containers
+managed by podman-compose restart automatically after a host reboot.
+
+- Script: `install-systemd-service.sh`
+- Purpose: Creates and enables systemd service for perfsonar-testpoint containers
+- Service file: `/etc/systemd/system/perfsonar-testpoint.service`
+- Must be run as root
+
+Usage:
+
+```bash
+# Install with default path (/opt/perfsonar-tp)
+sudo bash install-systemd-service.sh
+
+# Install with custom path
+sudo bash install-systemd-service.sh /custom/path/to/perfsonar-tp
+```
+
+After installation:
+- Containers will automatically start on boot
+- Use `systemctl start|stop|restart|status perfsonar-testpoint` to manage
+- View logs with `journalctl -u perfsonar-testpoint -f`
+
 Usage examples
 --------------
 

--- a/docs/perfsonar/tools_scripts/install-systemd-service.sh
+++ b/docs/perfsonar/tools_scripts/install-systemd-service.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# install-systemd-service.sh
+# --------------------------
+# Purpose:
+#   Install and enable a systemd service to manage perfSONAR testpoint containers
+#   with podman-compose. This ensures containers restart automatically after a 
+#   host reboot.
+#
+# Usage:
+#   sudo bash install-systemd-service.sh [/opt/perfsonar-tp]
+#
+# Arguments:
+#   $1 - Installation directory (default: /opt/perfsonar-tp)
+#
+# Requirements:
+#   - Root privileges (sudo)
+#   - podman-compose installed
+#   - perfSONAR testpoint docker-compose.yml in the installation directory
+#
+# Author: OSG perfSONAR deployment tools
+# Version: 1.0.0
+
+set -e
+
+# Default installation directory
+INSTALL_DIR="${1:-/opt/perfsonar-tp}"
+SERVICE_NAME="perfsonar-testpoint"
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   echo "ERROR: This script must be run as root (use sudo)" 
+   exit 1
+fi
+
+# Check if podman-compose is installed
+if ! command -v podman-compose &> /dev/null; then
+    echo "ERROR: podman-compose is not installed"
+    echo "Install it with: dnf install -y podman-compose"
+    exit 1
+fi
+
+# Check if installation directory exists
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    echo "ERROR: Installation directory does not exist: $INSTALL_DIR"
+    exit 1
+fi
+
+# Check if docker-compose.yml exists
+if [[ ! -f "$INSTALL_DIR/docker-compose.yml" ]]; then
+    echo "ERROR: docker-compose.yml not found in $INSTALL_DIR"
+    exit 1
+fi
+
+echo "==> Installing systemd service for perfSONAR testpoint"
+echo "    Installation directory: $INSTALL_DIR"
+echo "    Service file: $SERVICE_FILE"
+
+# Create systemd service file
+cat > "$SERVICE_FILE" << 'EOF'
+[Unit]
+Description=perfSONAR Testpoint Container Service
+After=network-online.target
+Wants=network-online.target
+RequiresMountsFor=/opt/perfsonar-tp
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/perfsonar-tp
+ExecStart=/usr/bin/podman-compose up -d
+ExecStop=/usr/bin/podman-compose down
+TimeoutStartSec=300
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Update WorkingDirectory if non-default path is used
+if [[ "$INSTALL_DIR" != "/opt/perfsonar-tp" ]]; then
+    sed -i "s|WorkingDirectory=/opt/perfsonar-tp|WorkingDirectory=$INSTALL_DIR|g" "$SERVICE_FILE"
+    sed -i "s|RequiresMountsFor=/opt/perfsonar-tp|RequiresMountsFor=$INSTALL_DIR|g" "$SERVICE_FILE"
+fi
+
+echo "==> Reloading systemd daemon"
+systemctl daemon-reload
+
+echo "==> Enabling $SERVICE_NAME service"
+systemctl enable "$SERVICE_NAME.service"
+
+echo "==> ✓ Systemd service installed and enabled successfully"
+echo ""
+echo "Useful commands:"
+echo "  Start service:   systemctl start $SERVICE_NAME"
+echo "  Stop service:    systemctl stop $SERVICE_NAME"
+echo "  Restart service: systemctl restart $SERVICE_NAME"
+echo "  Check status:    systemctl status $SERVICE_NAME"
+echo "  View logs:       journalctl -u $SERVICE_NAME -f"
+echo ""
+echo "The service will automatically start containers on boot."


### PR DESCRIPTION
Add systemd service support to ensure podman-compose containers restart automatically after a host reboot. This resolves the issue where perfSONAR testpoint containers would not restart after system reboots.

Changes:
- Add install-systemd-service.sh helper script for automated setup
- Create Ansible playbook for containerized testpoint deployment
- Update install-testpoint.md with automatic restart instructions
- Add systemd service documentation to tools_scripts README
- Include troubleshooting guide for container restart issues
- Update Ansible README with container deployment options

The systemd service manages podman-compose lifecycle and ensures containers start on boot with proper dependency ordering.

Fixes container restart loop issues by documenting proper cgroup configuration requirements for systemd containers.

Tested on local deployment at /opt/perfsonar-tp with successful container startup and service enablement.