### PR TITLE
Quick-deploy: add systemd reboot persistence; tools_scripts integration notes; orchestrator tip

### DIFF
--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -51,6 +51,20 @@ After installation:
 - Use `systemctl start|stop|restart|status perfsonar-testpoint` to manage
 - View logs with `journalctl -u perfsonar-testpoint -f`
 
+Integration tips
+----------------
+
+- Orchestrated installs: If you use `perfSONAR-orchestrator.sh`, you can run the systemd installer after the compose stack is up so containers start on boot. Example:
+
+  ```bash
+  /opt/perfsonar-tp/tools_scripts/install-systemd-service.sh /opt/perfsonar-tp
+  systemctl enable --now perfsonar-testpoint.service
+  ```
+
+- Manual installs: After `podman-compose up -d`, install and enable the service as shown above.
+
+- Updating compose files: Edit `/opt/perfsonar-tp/docker-compose.yml` and run `systemctl restart perfsonar-testpoint.service` to apply changes cleanly.
+
 Usage examples
 --------------
 

--- a/docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh
+++ b/docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh
@@ -389,6 +389,11 @@ step_validate() {
   if [ -n "$LE_FQDN" ]; then
     run bash -c "openssl s_client -connect $LE_FQDN:443 -servername $LE_FQDN -showcerts </dev/null 2>/dev/null | openssl x509 -noout -issuer -subject -dates" || true
   fi
+
+  # Recommend installing the systemd service for reboot persistence
+  log "Tip: Enable auto-restart on reboot by installing the systemd service:"
+  log "  /opt/perfsonar-tp/tools_scripts/install-systemd-service.sh /opt/perfsonar-tp"
+  log "  systemctl enable --now perfsonar-testpoint.service"
 }
 
 main() {

--- a/docs/personas/quick-deploy/install-perfsonar-testpoint.md
+++ b/docs/personas/quick-deploy/install-perfsonar-testpoint.md
@@ -452,6 +452,32 @@ The container should show `healthy` status. The healthcheck monitors Apache HTTP
 
 That's it for the testpoint-only mode. Manage pSConfig files under `/opt/perfsonar-tp/psconfig` on the host; they are consumed by the container at `/etc/perfsonar/psconfig`. Jump to Step 6 below.
 
+#### Ensure containers restart automatically on reboot (systemd service)
+
+Without a service manager, compose-managed containers may not come back after a host reboot. Install the provided systemd service to make container startup persistent across reboots:
+
+```bash
+curl -fsSL \
+    https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install-systemd-service.sh \
+    -o /tmp/install-systemd-service.sh
+chmod 0755 /tmp/install-systemd-service.sh
+
+# Install for compose directory /opt/perfsonar-tp
+/tmp/install-systemd-service.sh /opt/perfsonar-tp
+
+# Enable and start now
+systemctl enable --now perfsonar-testpoint.service
+
+# Verify service and containers
+systemctl status perfsonar-testpoint.service --no-pager
+podman ps
+```
+
+Notes:
+- The service uses `podman-compose up -d` at boot and `podman-compose down` on stop.
+- If you keep your compose files elsewhere, pass that directory as the first argument to the installer.
+- To update the compose files, edit `/opt/perfsonar-tp/docker-compose.yml` and run `systemctl restart perfsonar-testpoint.service`.
+
 ---
 
 ### Option B — Testpoint + Let's Encrypt (shared Apache and certs)
@@ -569,6 +595,21 @@ podman-compose up -d
 
 At this point, the testpoint is running with self-signed certificates. The certbot container is also
 running but won't renew anything until you obtain the initial certificates.
+
+#### Ensure containers restart automatically on reboot (systemd service)
+
+Install and enable the systemd service so the compose stack starts on boot:
+
+```bash
+curl -fsSL \
+    https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install-systemd-service.sh \
+    -o /tmp/install-systemd-service.sh
+chmod 0755 /tmp/install-systemd-service.sh
+
+/tmp/install-systemd-service.sh /opt/perfsonar-tp
+systemctl enable --now perfsonar-testpoint.service
+systemctl status perfsonar-testpoint.service --no-pager
+```
 
 #### 3) Obtain your first Let's Encrypt certificate (one-time)
 


### PR DESCRIPTION
This PR updates documentation and integration notes to ensure perfSONAR testpoint containers managed by podman-compose restart automatically after host reboot.

Changes:
- docs/personas/quick-deploy/install-perfsonar-testpoint.md: Added systemd service installation instructions under both Option A and Option B.
- docs/perfsonar/tools_scripts/README.md: Added integration tips recommending enabling the systemd service and how to apply compose changes cleanly.
- docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh: Added a tip at the end to install/enable the systemd service for reboot persistence (no behavior change).

Rationale:
- Addresses the previously observed issue where containers did not restart after reboot due to missing service management.

CI:
- Pure documentation/script comments; no functional changes to scripts. Markdownlint should pass; shellcheck unaffected.

Please review and merge to ensure guidance aligns with the new reboot-persistent setup.