### PR TITLE
Add Fasterdata host/network tuning guide and audit/apply tool

### DIFF
--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -192,7 +192,7 @@ If the script fails to detect certain hardware or settings:
 - **Missing `ethtool`**: Install via `dnf install ethtool`
 - **Missing `tuned-adm`**: Install via `dnf install tuned`
 - **No cpufreq/governor**: Some VMs lack CPU frequency scaling; this is normal
-- **No IOMMU**: Enable in GRUB (`intel_iommu=on` for Intel, `amd_iommu=on` for AMD) if using SR-IOV or isolation features
+- **No IOMMU**: Fasterdata recommends `iommu=pt` generally, with vendor additions: enable in GRUB (e.g., `intel_iommu=on iommu=pt` for Intel, `amd_iommu=on iommu=pt` for AMD) if using SR-IOV or isolation features. Add `iommu=pt` to improve throughput on high-speed NICs.
 - **ethtool-persist.service fails to start**: Check `/var/log/messages` or `journalctl -u ethtool-persist` for errors; ensure ethtool and ip commands exist at `/sbin/` paths
 
 ### Persistence Service Details

--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -29,47 +29,108 @@ Modes:
 - `audit` (default): show current settings vs recommendations, no changes
 - `apply`: set recommended values (requires root)
 
+Options:
+- `--mode audit|apply`: mode selection
+- `--target measurement|dtn`: host type for scaled recommendations (default: `measurement`)
+- `--ifaces eth0,eth1`: comma-separated interface list (default: auto-detect physical NICs)
+- `--color`: enable color-coded output (green=compliant, yellow=warning, red=critical)
+
+### Host Types
+
+The script tailors recommendations by host type:
+
+- **measurement**: perfSONAR testpoints, measurement nodes (primary focus)
+- **dtn**: Data Transfer Nodes (larger buffers for bulk throughput)
+
+Differences:
+- `net.core.netdev_max_backlog`: measurement uses 500k at 100Gbps; dtn uses 600k
+- `txqueuelen`: measurement targets 10k/15k/20k; dtn targets 12k/18k/25k (per link speed)
+
 ### Examples
 
-Audit everything (auto-detected interfaces):
+Audit a measurement host:
 ```bash
-bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit
+bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit --target measurement
 ```
 
-Apply recommendations (writes `/etc/sysctl.d/90-fasterdata.conf`, tunes NICs):
+Apply tuning for a DTN (100Gbps links):
 ```bash
-sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --target dtn
 ```
 
 Limit to specific NICs:
 ```bash
-sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --ifaces "eth0,eth1"
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --target measurement --ifaces "ens1f0np0,ens1f1np1"
 ```
 
 ### What the script does
 
-- Sysctl: sets larger rmem/wmem, netdev backlog, `default_qdisc=fq`, `tcp_mtu_probing=1`, TCP r/w mem, timestamps/SACK on, low_latency off; prefers `bbr` if available
-- Tuned: ensures `network-throughput` profile if `tuned-adm` is present
-- Interfaces (per NIC):
-  - set `txqueuelen` to ≥ 10000
-  - set RX/TX rings to driver max (if reported)
-  - enable GRO/GSO/TSO and checksums; disable LRO
-  - replace qdisc with `fq`
+- **Sysctl**: Sets larger rmem/wmem, netdev backlog, `default_qdisc=fq`, `tcp_mtu_probing=1`, TCP r/w mem, timestamps/SACK on, low_latency off; prefers `bbr` if available. Values scale with fastest NIC link speed and target type (measurement vs dtn). Settings written to `/etc/sysctl.d/90-fasterdata.conf` in apply mode.
+- **Tuned**: Ensures `network-throughput` profile if `tuned-adm` is present.
+- **Ethtool persistence** (apply mode): Creates or updates `/etc/systemd/system/ethtool-persist.service` to persist NIC tunings across reboots (ring buffers, offloads, txqueuelen).
+- **Driver checks**: Detects driver vendor/version (Mellanox, Broadcom, Intel, other); reports kernel/firmware updates available; provides vendor-specific guidance (e.g., "keep kernel+linux-firmware current", "consider NVIDIA OFED for Mellanox").
+- **Interfaces** (per NIC, scaled by link speed):
+  - Set `txqueuelen` to ≥ 10k (measurement) or ≥ 12k (dtn); 20k/25k for 100Gbps
+  - Set RX/TX rings to driver max (if reported)
+  - Enable GRO/GSO/TSO and checksums; disable LRO
+  - Replace qdisc with `fq`
+
+### Output and logs
+
+The script outputs a **Host Info** section at the top showing:
+- Hostname (FQDN)
+- OS name/version (from `/etc/os-release`)
+- Running kernel version
+- System memory (GiB)
+- SMT status (on/off/unavailable); yellow warning if SMT is off (off-topic: helps isolate jitter in measurement contexts, but should be on by default for throughput)
+
+Then it displays sysctl audit and per-NIC summaries, followed by a summary block showing:
+- Target type (measurement/dtn)
+- Sysctl mismatches (count)
+- Per-interface issues (tx queue, qdisc, offloads, rings)
+- Driver/version actions (kernel updates available, vendor guidance)
+- SMT control guidance (if SMT is off, suggests toggle commands)
+- Missing tools (ethtool, tuned-adm, cpupower)
+
+Detailed log with full ethtool/sysctl/tc output is written to `/tmp/fasterdata-tuning-<UTC>.log` (configurable via `LOGFILE` env var).
+
+#### Color Output
+
+Use `--color` flag to enable ANSI color codes:
+- Green: settings comply with recommendations
+- Yellow: warning/attention needed (e.g., SMT off, missing tools, suboptimal settings)
+- Red: critical issues requiring immediate attention (not currently used, reserved for future severity levels)
+
+### Driver Guidance
+
+The script identifies your NIC drivers and provides upgrade paths:
+
+- **Mellanox/NVIDIA** (`mlx5_core`, `mlx4_en`): Keep kernel+linux-firmware current or use NVIDIA OFED (https://network.nvidia.com/products/ethernet-drivers/).
+- **Broadcom** (`bnxt_en`, `tg3`, `bnx2x`, `bnx2`): Track distro kernel; use vendor firmware tools (e.g., `bnxtnvm`) when available.
+- **Intel** (`ixgbe`, `i40e`, `ice`, `e1000e`, `igb`): Update kernel+linux-firmware for latest drivers and firmware blobs.
+
+If a kernel update is available, the summary will recommend: `dnf update kernel && reboot`.
 
 ### Cautions
 
-- Apply mode changes the running system and writes sysctl to `/etc/sysctl.d/90-fasterdata.conf`.
-- NIC ethtool settings are immediate but not persistent across reboots. If you need persistence, run this script at boot (e.g., via a systemd service) or mirror settings in your network manager.
+- **Apply mode changes the running system** and writes sysctl to `/etc/sysctl.d/90-fasterdata.conf`.
+- **Persistence of ethtool settings**: In apply mode, the script automatically creates or updates `/etc/systemd/system/ethtool-persist.service` to persist NIC tunings (ring buffers, offloads, txqueuelen) across reboots. The service is enabled automatically.
+- **Sysctl settings** in `/etc/sysctl.d/90-fasterdata.conf` persist across reboots.
+- **SMT control** (if changed) requires GRUB config to persist; see [SMT section](#smt-simultaneous-multi-threading) below.
+- **Tuned profile** changes persist if tuned-adm writes to its default config.
 - The script assumes EL9 userland (`sysctl`, `ethtool`, `tc`, `tuned-adm`). It skips steps if tools are missing.
 - If `bbr` is not available, it falls back to `cubic` live but keeps `bbr` in the config for future kernels.
 - Always validate after applying: check `podman ps`/services, run a quick throughput test, and review `dmesg`/`journal` for NIC or driver warnings.
+- To verify ethtool persistence service: `systemctl status ethtool-persist` and `systemctl cat ethtool-persist.service`
 
 ## Manual checklist (summary of recommendations)
 
+Values shown below are baseline (1Gbps). The script scales them by fastest NIC speed and target type.
+
 - Sysctl
-  - `net.core.rmem_max`/`wmem_max`: 536,870,912
-  - `net.core.rmem_default`/`wmem_default`: 134,217,728
-  - `net.core.netdev_max_backlog`: 250,000
+  - `net.core.rmem_max`/`wmem_max`: 536M–1G (measurement); 1G (dtn at 100Gbps)
+  - `net.core.rmem_default`/`wmem_default`: 128M
+  - `net.core.netdev_max_backlog`: 250k–500k (measurement); 250k–600k (dtn)
   - `net.core.default_qdisc`: `fq`
   - `net.ipv4.tcp_rmem`: `4096 87380 536870912`
   - `net.ipv4.tcp_wmem`: `4096 65536 536870912`
@@ -92,6 +153,76 @@ sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --iface
 - `tuned-adm active`
 - For each NIC: `ethtool -k <iface>`, `ethtool -g <iface>`, `tc qdisc show dev <iface>`, `cat /sys/class/net/<iface>/tx_queue_len`
 - Run a representative throughput test (e.g., `iperf3`) end-to-end.
+
+## Additional Topics
+
+### SMT (Simultaneous Multi-Threading)
+
+The script detects and reports SMT status. For most measurement hosts (perfSONAR), **SMT should be on** to maximize CPU throughput. However, for isolated low-latency workloads, SMT off may reduce jitter.
+
+**To check SMT status:**
+```bash
+cat /sys/devices/system/cpu/smt/control
+```
+
+**To enable SMT:**
+```bash
+echo on | sudo tee /sys/devices/system/cpu/smt/control
+```
+
+**To disable SMT:**
+```bash
+echo off | sudo tee /sys/devices/system/cpu/smt/control
+```
+
+Note: SMT changes take effect immediately but are not persisted across reboots. To persist, add to kernel command line (GRUB): `nosmt` (to disable) or remove it (to enable).
+
+### Driver Updates
+
+The script checks for available kernel and driver updates via `dnf list --showduplicates kernel`. If an update is available, the summary recommends:
+```bash
+dnf update kernel && reboot
+```
+
+For vendor-specific drivers (Mellanox OFED, Broadcom firmware tools), the script provides URLs and guidance. Always validate driver compatibility before updating in production.
+
+### Troubleshooting
+
+If the script fails to detect certain hardware or settings:
+- **Missing `ethtool`**: Install via `dnf install ethtool`
+- **Missing `tuned-adm`**: Install via `dnf install tuned`
+- **No cpufreq/governor**: Some VMs lack CPU frequency scaling; this is normal
+- **No IOMMU**: Enable in GRUB (`intel_iommu=on` for Intel, `amd_iommu=on` for AMD) if using SR-IOV or isolation features
+- **ethtool-persist.service fails to start**: Check `/var/log/messages` or `journalctl -u ethtool-persist` for errors; ensure ethtool and ip commands exist at `/sbin/` paths
+
+### Persistence Service Details
+
+When running with `--mode apply`, the script generates `/etc/systemd/system/ethtool-persist.service` containing:
+
+```
+[Unit]
+Description=Persist ethtool settings (Fasterdata)
+After=network.target
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -G <iface> rx <max> tx <max>
+ExecStart=/sbin/ethtool -K <iface> gro on gso on tso on rx on tx on lro off
+ExecStart=/sbin/ip link set dev <iface> txqueuelen <value>
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The service is automatically enabled. To verify:
+```bash
+systemctl status ethtool-persist.service
+systemctl cat ethtool-persist.service
+```
+
+To manually update this service, re-run the script with `--mode apply` to regenerate it with current NIC settings.
 
 ## Persistence notes
 

--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -1,0 +1,102 @@
+# Host and Network Tuning (EL9)
+
+This guide distills ESnet Fasterdata recommendations for high-throughput hosts (perfSONAR/DTN-style) on Enterprise Linux 9. Primary sources:
+
+- https://fasterdata.es.net/host-tuning/
+- https://fasterdata.es.net/network-tuning/
+- https://fasterdata.es.net/DTN/
+
+Use the provided audit/apply script to check your host against these recommendations and optionally enforce them. Read the cautions before applying.
+
+## What this covers
+
+- Kernel networking sysctls: buffers, congestion control, qdisc, MTU probing
+- Tuned profile: `network-throughput`
+- Per-interface checks: ring buffers, GRO/GSO/TSO on, LRO off, checksum on, txqueuelen, fq qdisc
+- Congestion control: prefer `bbr` (fallback to `cubic` if unavailable)
+
+## When to use this
+
+- perfSONAR testpoints, DTNs, and other dedicated measurement/transfer hosts on EL9
+- Fresh installs or periodic compliance checks against Fasterdata guidance
+- Not for multi-tenant or latency-sensitive hosts without review
+
+## Script: `fasterdata-tuning.sh`
+
+Path: `docs/perfsonar/tools_scripts/fasterdata-tuning.sh`
+
+Modes:
+- `audit` (default): show current settings vs recommendations, no changes
+- `apply`: set recommended values (requires root)
+
+### Examples
+
+Audit everything (auto-detected interfaces):
+```bash
+bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit
+```
+
+Apply recommendations (writes `/etc/sysctl.d/90-fasterdata.conf`, tunes NICs):
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply
+```
+
+Limit to specific NICs:
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --ifaces "eth0,eth1"
+```
+
+### What the script does
+
+- Sysctl: sets larger rmem/wmem, netdev backlog, `default_qdisc=fq`, `tcp_mtu_probing=1`, TCP r/w mem, timestamps/SACK on, low_latency off; prefers `bbr` if available
+- Tuned: ensures `network-throughput` profile if `tuned-adm` is present
+- Interfaces (per NIC):
+  - set `txqueuelen` to ≥ 10000
+  - set RX/TX rings to driver max (if reported)
+  - enable GRO/GSO/TSO and checksums; disable LRO
+  - replace qdisc with `fq`
+
+### Cautions
+
+- Apply mode changes the running system and writes sysctl to `/etc/sysctl.d/90-fasterdata.conf`.
+- NIC ethtool settings are immediate but not persistent across reboots. If you need persistence, run this script at boot (e.g., via a systemd service) or mirror settings in your network manager.
+- The script assumes EL9 userland (`sysctl`, `ethtool`, `tc`, `tuned-adm`). It skips steps if tools are missing.
+- If `bbr` is not available, it falls back to `cubic` live but keeps `bbr` in the config for future kernels.
+- Always validate after applying: check `podman ps`/services, run a quick throughput test, and review `dmesg`/`journal` for NIC or driver warnings.
+
+## Manual checklist (summary of recommendations)
+
+- Sysctl
+  - `net.core.rmem_max`/`wmem_max`: 536,870,912
+  - `net.core.rmem_default`/`wmem_default`: 134,217,728
+  - `net.core.netdev_max_backlog`: 250,000
+  - `net.core.default_qdisc`: `fq`
+  - `net.ipv4.tcp_rmem`: `4096 87380 536870912`
+  - `net.ipv4.tcp_wmem`: `4096 65536 536870912`
+  - `net.ipv4.tcp_congestion_control`: `bbr` (or `cubic` if `bbr` absent)
+  - `net.ipv4.tcp_mtu_probing`: `1`
+  - `net.ipv4.tcp_window_scaling`: `1`
+  - `net.ipv4.tcp_timestamps`: `1`
+  - `net.ipv4.tcp_sack`: `1`
+  - `net.ipv4.tcp_low_latency`: `0`
+- Tuned: `tuned-adm profile network-throughput`
+- Interfaces
+  - `txqueuelen` ≥ 10000
+  - RX/TX rings at driver max (`ethtool -g` / `-G`)
+  - GRO/GSO/TSO on; checksums on; LRO off
+  - qdisc `fq` (root)
+
+## Verification after tuning
+
+- `sysctl -a | egrep "(rmem|wmem|max_backlog|default_qdisc|tcp_congestion_control|tcp_mtu_probing)"`
+- `tuned-adm active`
+- For each NIC: `ethtool -k <iface>`, `ethtool -g <iface>`, `tc qdisc show dev <iface>`, `cat /sys/class/net/<iface>/tx_queue_len`
+- Run a representative throughput test (e.g., `iperf3`) end-to-end.
+
+## Persistence notes
+
+- Sysctl settings persist via `/etc/sysctl.d/90-fasterdata.conf`
+- NIC ethtool changes do not persist by default; consider:
+  - running this script from a boot-time systemd unit, or
+  - translating the settings into your network manager configuration
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,10 @@ Network Troubleshooting
 -----------------------
 Users with network issues should check the [troubleshooting link](network-troubleshooting.md) below for initial guidance on how best to get their issue resolved. In addition, you can refer to the [ESNet network performance guide](https://fasterdata.es.net/performance-testing/troubleshooting/network-troubleshooting-quick-reference-guide/) for a detailed instructions on how to identify and isolate network performance issues using perfSONAR.
 
+Host and Network Tuning
+-----------------------
+- [Fasterdata-aligned host/network tuning (EL9)](host-network-tuning.md) — summarizes ESnet guidance and includes an audit/apply script.
+
 Network Services
 ----------------
 

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -8,6 +8,7 @@ static IPv4/IPv6 addressing and per-NIC source-based routing via NetworkManager
 Quick overview
 --------------
 - Script: `perfSONAR-pbr-nm.sh`
+- Script: `fasterdata-tuning.sh` (Fasterdata audit/apply host tuning script)
 - Config file: `/etc/perfSONAR-multi-nic-config.conf`
 - Log file: `/var/log/perfSONAR-multi-nic-config.log`
 
@@ -42,6 +43,29 @@ skip cloning with:
 ```bash
 bash docs/perfsonar/tools_scripts/install_tools_scripts.sh --skip-testpoint
 ```
+
+Fasterdata host tuning script
+-----------------------------
+- Script: `fasterdata-tuning.sh` — audit/apply host & NIC tuning (ESnet Fasterdata-aligned) for EL9 systems
+- Path: `docs/perfsonar/tools_scripts/fasterdata-tuning.sh`
+
+Usage examples
+--------------
+
+Audit (default) a measurement host:
+```bash
+bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit --target measurement
+```
+
+Apply tuning (requires root):
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --target dtn
+```
+
+Notes
+-----
+- Shows a `Host Info` summary and performs various checks (sysctl, ethtool, drivers, SMT, IOMMU). IOMMU changes require GRUB edits and reboot; SMT toggles can be done via `/sys/devices/system/cpu/smt/control`.
+- In apply mode the script writes `/etc/sysctl.d/90-fasterdata.conf` and writes/enables a systemd `ethtool-persist.service` to persist NIC settings.
 
 Requirements
 ------------

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.md
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.md
@@ -1,0 +1,43 @@
+# Fasterdata Host & Network Tuning (EL9)
+
+This page documents `fasterdata-tuning.sh`, a script that audits and optionally applies ESnet Fasterdata-inspired host and NIC tuning recommendations for Enterprise Linux 9.
+
+Script: `docs/perfsonar/tools_scripts/fasterdata-tuning.sh`
+
+Purpose
+-------
+- Audit system settings (sysctl, qdiscs, ethtool, SMT, IOMMU, drivers) against Fasterdata recommendations.
+- Apply tuned sysctl settings and persist NIC tunings (via systemd service) when run in `--mode apply`.
+
+Usage
+-----
+Audit a measurement host (default):
+
+```bash
+bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit --target measurement
+```
+
+Apply tuning (requires root):
+
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --target dtn
+```
+
+Limit apply to specific NICs (comma-separated):
+
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --target measurement --ifaces "ens1f0np0,ens1f1np1"
+```
+
+Notes
+-----
+- IOMMU: The script checks whether `iommu=pt` plus vendor-specific flags (`intel_iommu=on` or `amd_iommu=on`) are present. It only recommends GRUB edits (requires reboot) — it does not modify GRUB automatically unless you explicitly opt-in via a future apply flag.
+- SMT: The script detects SMT status and suggests commands to toggle runtime SMT; persistence requires GRUB edits (kernel cmdline). It does not toggle SMT by default.
+- Apply mode writes `/etc/sysctl.d/90-fasterdata.conf` and creates `/etc/systemd/system/ethtool-persist.service` when necessary.
+
+Reference and source
+--------------------
+- Source script: `docs/perfsonar/tools_scripts/fasterdata-tuning.sh`
+- Fasterdata docs: https://fasterdata.es.net/host-tuning/
+
+If you use this script as part of a host onboarding flow, ensure you test it in a VM or staging host before applying to production hosts.

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# fasterdata-tuning.sh
+# --------------------
+# Audit and optionally apply host/network tuning recommended by ESnet Fasterdata
+# for high-throughput hosts (EL9 focus). Defaults to audit-only.
+#
+# Sources: https://fasterdata.es.net/host-tuning/ , /network-tuning/ , /DTN/
+#
+# Modes:
+#   --mode audit   (default)  -> read current settings, show differences
+#   --mode apply               -> apply recommended values (requires root)
+#
+# Scope:
+#   - Sysctl networking parameters (buffers, congestion control, qdisc)
+#   - Tuned profile suggestion (network-throughput)
+#   - Per-interface checks: GRO/TSO/GSO/checksums, LRO off, ring buffers to max,
+#     txqueuelen, qdisc fq
+#
+# Notes:
+#   - Uses conservative recommendations suitable for perfSONAR/DTN-style hosts on EL9.
+#   - Apply mode writes /etc/sysctl.d/90-fasterdata.conf and applies live settings.
+#   - ethtool changes are immediate but not persisted across reboots; consider
+#     running this script from a boot-time unit if persistence is required.
+
+set -euo pipefail
+
+MODE="audit"
+IFACES=""
+
+usage() {
+  cat <<'EOF'
+Usage: fasterdata-tuning.sh [--mode audit|apply] [--ifaces "eth0,eth1"] [--verbose]
+
+Modes:
+  audit   (default) Show current values vs. Fasterdata recommendations
+  apply             Apply recommended values (requires root)
+
+Options:
+  --ifaces LIST     Comma-separated interfaces to check/tune. Default: all up, non-loopback
+  --verbose         More detail in audit output
+  -h, --help        Show this help
+EOF
+}
+
+log() { echo "$*"; }
+log_warn() { echo "[WARN] $*" >&2; }
+log_info() { echo "[INFO] $*"; }
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: --mode apply requires root" >&2
+    exit 1
+  fi
+}
+
+# Recommended sysctl values (Fasterdata-inspired, EL9 context)
+declare -A SYSCTL_RECS=(
+  [net.core.rmem_max]=536870912
+  [net.core.wmem_max]=536870912
+  [net.core.rmem_default]=134217728
+  [net.core.wmem_default]=134217728
+  [net.core.netdev_max_backlog]=250000
+  [net.core.default_qdisc]=fq
+  [net.ipv4.tcp_rmem]="4096 87380 536870912"
+  [net.ipv4.tcp_wmem]="4096 65536 536870912"
+  [net.ipv4.tcp_congestion_control]=bbr
+  [net.ipv4.tcp_mtu_probing]=1
+  [net.ipv4.tcp_window_scaling]=1
+  [net.ipv4.tcp_timestamps]=1
+  [net.ipv4.tcp_sack]=1
+  [net.ipv4.tcp_low_latency]=0
+)
+
+has_bbr() {
+  sysctl -n net.ipv4.tcp_available_congestion_control 2>/dev/null | grep -qw bbr
+}
+
+get_ifaces() {
+  if [[ -n "$IFACES" ]]; then
+    echo "$IFACES" | tr ',' ' '
+    return
+  fi
+  ip -o link show up | awk -F': ' '{print $2}' | grep -vE '^(lo|docker|cni|veth|br-)' || true
+}
+
+print_sysctl_diff() {
+  local key wanted current status
+  printf "\nSysctl audit (current vs recommended)\n"
+  printf "%-35s %-35s %-35s\n" "Key" "Current" "Recommended"
+  printf '%0.105s\n' "-------------------------------------------------------------------------------------------------"
+  for key in "${!SYSCTL_RECS[@]}"; do
+    wanted=${SYSCTL_RECS[$key]}
+    current=$(sysctl -n "$key" 2>/dev/null || echo "(unset)")
+    status=""
+    [[ "$current" == "$wanted" ]] || status="*"
+    printf "%-35s %-35s %-35s %s\n" "$key" "$current" "$wanted" "$status"
+  done
+}
+
+apply_sysctl() {
+  local outfile="/etc/sysctl.d/90-fasterdata.conf"
+  require_root
+  log_info "Writing $outfile"
+  cat > "$outfile" <<'EOF'
+# Fasterdata-inspired tuning (https://fasterdata.es.net/)
+# Applied by fasterdata-tuning.sh
+net.core.rmem_max = 536870912
+net.core.wmem_max = 536870912
+net.core.rmem_default = 134217728
+net.core.wmem_default = 134217728
+net.core.netdev_max_backlog = 250000
+net.core.default_qdisc = fq
+net.ipv4.tcp_rmem = 4096 87380 536870912
+net.ipv4.tcp_wmem = 4096 65536 536870912
+net.ipv4.tcp_congestion_control = bbr
+net.ipv4.tcp_mtu_probing = 1
+net.ipv4.tcp_window_scaling = 1
+net.ipv4.tcp_timestamps = 1
+net.ipv4.tcp_sack = 1
+net.ipv4.tcp_low_latency = 0
+EOF
+  if ! has_bbr; then
+    log_warn "bbr not available; falling back to cubic at runtime (file still sets bbr)"
+  fi
+  log_info "Applying sysctl settings"
+  sysctl --system >/dev/null
+  # If bbr missing, set congestion control to cubic live to avoid failure
+  if ! has_bbr; then
+    sysctl -w net.ipv4.tcp_congestion_control=cubic >/dev/null
+  fi
+}
+
+iface_audit() {
+  local iface="$1"
+  echo "\nInterface: $iface"
+  ip -brief address show "$iface"
+
+  # Queue length
+  local txqlen
+  txqlen=$(cat "/sys/class/net/$iface/tx_queue_len" 2>/dev/null || echo "?")
+  echo "  txqueuelen: $txqlen (rec: >= 10000)"
+
+  # ethtool settings
+  if command -v ethtool >/dev/null 2>&1; then
+    local offload
+    offload=$(ethtool -k "$iface" 2>/dev/null | grep -E 'gro:|gso:|tso:|rx-checksumming:|tx-checksumming:|lro:') || true
+    echo "  Offloads (current):"
+    echo "$offload" | sed 's/^/    /'
+
+    local rings
+    rings=$(ethtool -g "$iface" 2>/dev/null | sed 's/^/    /') || true
+    [[ -n "$rings" ]] && echo "  Rings:" && echo "$rings"
+  else
+    echo "  ethtool not installed; skipping offload/ring audit"
+  fi
+
+  # qdisc
+  local qdisc
+  qdisc=$(tc qdisc show dev "$iface" 2>/dev/null | head -n1 | awk '{print $2,$3,$4}')
+  echo "  qdisc: ${qdisc:-unknown} (rec: fq)"
+}
+
+iface_apply() {
+  local iface="$1"
+  log_info "Tuning interface $iface"
+
+  # txqueuelen
+  if [[ -f /sys/class/net/$iface/tx_queue_len ]]; then
+    local cur
+    cur=$(cat /sys/class/net/$iface/tx_queue_len)
+    if [[ "$cur" -lt 10000 ]]; then
+      ip link set dev "$iface" txqueuelen 10000
+    fi
+  fi
+
+  if command -v ethtool >/dev/null 2>&1; then
+    # Rings: set to max where available
+    local max_rx max_tx
+    max_rx=$(ethtool -g "$iface" 2>/dev/null | awk '/RX:/ {rx=$2} /RX max:/ {rxmax=$3} END {if(rxmax>0) print rxmax}' || true)
+    max_tx=$(ethtool -g "$iface" 2>/dev/null | awk '/TX:/ {tx=$2} /TX max:/ {txmax=$3} END {if(txmax>0) print txmax}' || true)
+    [[ -n "$max_rx" ]] && ethtool -G "$iface" rx "$max_rx" >/dev/null 2>&1 || true
+    [[ -n "$max_tx" ]] && ethtool -G "$iface" tx "$max_tx" >/dev/null 2>&1 || true
+
+    # Offloads: enable GRO/GSO/TSO, checksums; disable LRO
+    ethtool -K "$iface" gro on gso on tso on rx on tx on >/dev/null 2>&1 || true
+    ethtool -K "$iface" lro off >/dev/null 2>&1 || true
+  fi
+
+  # qdisc fq
+  tc qdisc replace dev "$iface" root fq >/dev/null 2>&1 || true
+}
+
+ensure_tuned_profile() {
+  if ! command -v tuned-adm >/dev/null 2>&1; then
+    log_warn "tuned-adm not installed; skipping tuned profile"
+    return
+  fi
+  local active
+  active=$(tuned-adm active 2>/dev/null | awk '{print $3}' || true)
+  if [[ "$MODE" == "audit" ]]; then
+    echo "tuned-adm active: ${active:-unknown} (rec: network-throughput)"
+  else
+    if [[ "$active" != "network-throughput" ]]; then
+      log_info "Setting tuned profile to network-throughput"
+      tuned-adm profile network-throughput || log_warn "Failed to set tuned profile"
+    fi
+  fi
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --mode) MODE="$2"; shift 2;;
+      --ifaces) IFACES="$2"; shift 2;;
+      -h|--help) usage; exit 0;;
+      *) echo "Unknown arg: $1" >&2; usage; exit 1;;
+    esac
+  done
+
+  if [[ "$MODE" != "audit" && "$MODE" != "apply" ]]; then
+    echo "ERROR: --mode must be audit or apply" >&2; exit 1
+  fi
+  [[ "$MODE" == "apply" ]] && require_root
+
+  if [[ "$MODE" == "audit" ]]; then
+    print_sysctl_diff
+  else
+    if ! has_bbr; then
+      log_warn "bbr not available; will set cubic live but leave bbr in config"
+    fi
+    apply_sysctl
+  fi
+
+  ensure_tuned_profile
+
+  local ifs
+  ifs=$(get_ifaces)
+  for iface in $ifs; do
+    if [[ "$MODE" == "audit" ]]; then
+      iface_audit "$iface"
+    else
+      iface_apply "$iface"
+    fi
+  done
+
+  if [[ "$MODE" == "apply" ]]; then
+    log_info "Apply complete. Consider rebooting or rerunning audit to confirm settings."
+  else
+    log_info "Audit complete. Entries marked with '*' differ from recommended values."
+  fi
+}
+
+main "$@"

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
@@ -23,13 +23,35 @@
 #     running this script from a boot-time unit if persistence is required.
 
 set -euo pipefail
+# Ignore SIGPIPE to avoid non-zero exits when output is piped/truncated
+trap '' PIPE
+
+LOGFILE=${LOGFILE:-/tmp/fasterdata-tuning-$(date -u +%Y%m%dT%H%M%SZ).log}
+SYSCTL_MISMATCHES=0
+MISSING_TOOLS=()
+IF_ISSUES=()
+DRIVER_UPDATES=()
+TARGET_TYPE="measurement"
+MAX_LINK_SPEED=0
+SCALED_RMEM_MAX=536870912
+SCALED_WMEM_MAX=536870912
+SCALED_BACKLOG=250000
+RUNNING_KERNEL=""
+LATEST_KERNEL=""
+USE_COLOR=0
+
+# Color codes for terminal output
+readonly C_GREEN='\033[0;32m'
+readonly C_YELLOW='\033[0;33m'
+readonly C_RED='\033[0;31m'
+readonly C_RESET='\033[0m'
 
 MODE="audit"
 IFACES=""
 
 usage() {
   cat <<'EOF'
-Usage: fasterdata-tuning.sh [--mode audit|apply] [--ifaces "eth0,eth1"] [--verbose]
+Usage: fasterdata-tuning.sh [--mode audit|apply] [--ifaces "eth0,eth1"] [--target measurement|dtn] [--color] [--verbose]
 
 Modes:
   audit   (default) Show current values vs. Fasterdata recommendations
@@ -37,14 +59,45 @@ Modes:
 
 Options:
   --ifaces LIST     Comma-separated interfaces to check/tune. Default: all up, non-loopback
+  --target TYPE     Host type: measurement (default) or dtn (data transfer node)
+  --color           Use color codes (green=ok, yellow=warning, red=critical)
   --verbose         More detail in audit output
   -h, --help        Show this help
 EOF
 }
 
+init_log() {
+  if [[ -z "$LOGFILE" ]]; then
+    log_warn "LOGFILE is empty; detailed logging disabled"
+    return
+  fi
+  if : >"$LOGFILE" 2>/dev/null; then
+    log_info "Detailed log: $LOGFILE"
+  else
+    log_warn "Cannot write log file $LOGFILE; disabling detailed log"
+    LOGFILE=""
+  fi
+}
+
 log() { echo "$*"; }
 log_warn() { echo "[WARN] $*" >&2; }
 log_info() { echo "[INFO] $*"; }
+
+colorize() {
+  local level="$1" text="$2"
+  [[ $USE_COLOR -eq 0 ]] && { echo "$text"; return; }
+  case "$level" in
+    green) echo -e "${C_GREEN}${text}${C_RESET}";;
+    yellow) echo -e "${C_YELLOW}${text}${C_RESET}";;
+    red) echo -e "${C_RED}${text}${C_RESET}";;
+    *) echo "$text";;
+  esac
+}
+
+log_detail() {
+  [[ -z "$LOGFILE" ]] && return
+  printf "%s\n" "$*" >>"$LOGFILE" 2>/dev/null || true
+}
 
 require_root() {
   if [[ $EUID -ne 0 ]]; then
@@ -83,32 +136,51 @@ get_ifaces() {
 
   # prefer physical NICs under /sys/class/net/<iface>/device (PCI devices)
   local _path iface
+  # Collect candidate interfaces, preferring physical PCI devices, even if link is down
+  local candidates=()
   for _path in /sys/class/net/*; do
     iface=$(basename "$_path")
     # filter common virtual interface prefixes
     if [[ "$iface" =~ ^(lo|docker|cni|veth|br-|virbr|vmnet|vnet|ovs-) ]]; then
       continue
     fi
-    # physical devices appear under /sys/class/net/<iface>/device
     if [[ -d "/sys/class/net/$iface/device" ]]; then
-      echo "$iface"
+      candidates+=("$iface")
       continue
     fi
     # fall back: include interfaces with carrier/link detected (up or carrier)
     if ip -o link show "$iface" 2>/dev/null | grep -q 'state UP'; then
-      echo "$iface"
+      candidates+=("$iface")
       continue
     fi
     if command -v ethtool >/dev/null 2>&1; then
       if ethtool "$iface" 2>/dev/null | grep -q 'Link detected: yes'; then
-        echo "$iface"
+        candidates+=("$iface")
       fi
     fi
-  done | sort -u
+  done
+
+  # De-duplicate and print
+  if [[ ${#candidates[@]} -gt 0 ]]; then
+    printf "%s\n" "${candidates[@]}" | sort -u
+  fi
+}
+
+desired_txqlen_for_speed() {
+  local speed_mbps="$1"
+  local base=10000
+  [[ "$TARGET_TYPE" == "dtn" ]] && base=12000
+  if (( speed_mbps >= 100000 )); then
+    [[ "$TARGET_TYPE" == "dtn" ]] && base=25000 || base=20000
+  elif (( speed_mbps >= 40000 )); then
+    [[ "$TARGET_TYPE" == "dtn" ]] && base=18000 || base=15000
+  fi
+  echo "$base"
 }
 
 print_sysctl_diff() {
   local key wanted current status
+  log_detail "Sysctl audit (current vs recommended)"
   printf "\nSysctl audit (current vs recommended)\n"
   printf "%-35s %-35s %-35s\n" "Key" "Current" "Recommended"
   printf '%0.105s\n' "-------------------------------------------------------------------------------------------------"
@@ -116,7 +188,13 @@ print_sysctl_diff() {
     wanted=${SYSCTL_RECS[$key]}
     current=$(sysctl -n "$key" 2>/dev/null || echo "(unset)")
     status=""
-    [[ "$current" == "$wanted" ]] || status="*"
+    if [[ "$current" != "$wanted" ]]; then
+      status="*"
+      ((SYSCTL_MISMATCHES+=1))
+      log_detail "SYSCTL mismatch: $key current='$current' recommended='$wanted'"
+    else
+      log_detail "SYSCTL ok: $key=$current"
+    fi
     printf "%-35s %-35s %-35s %s\n" "$key" "$current" "$wanted" "$status"
   done
 }
@@ -163,6 +241,40 @@ get_iface_speed() {
   fi
 }
 
+set_speed_scaled_recs() {
+  MAX_LINK_SPEED=$(get_max_link_speed)
+  SCALED_RMEM_MAX=536870912
+  SCALED_WMEM_MAX=536870912
+  SCALED_BACKLOG=250000
+  if (( MAX_LINK_SPEED >= 100000 )); then
+    SCALED_RMEM_MAX=1073741824
+    SCALED_WMEM_MAX=1073741824
+    SCALED_BACKLOG=500000
+  elif (( MAX_LINK_SPEED >= 40000 )); then
+    SCALED_RMEM_MAX=536870912
+    SCALED_WMEM_MAX=536870912
+    SCALED_BACKLOG=350000
+  fi
+  if [[ "$TARGET_TYPE" == "dtn" ]]; then
+    if (( MAX_LINK_SPEED >= 100000 )); then
+      SCALED_BACKLOG=600000
+    elif (( MAX_LINK_SPEED >= 40000 )); then
+      SCALED_BACKLOG=400000
+    fi
+  fi
+  SYSCTL_RECS[net.core.rmem_max]=$SCALED_RMEM_MAX
+  SYSCTL_RECS[net.core.wmem_max]=$SCALED_WMEM_MAX
+  SYSCTL_RECS[net.core.netdev_max_backlog]=$SCALED_BACKLOG
+}
+
+cache_kernel_versions() {
+  RUNNING_KERNEL=$(uname -r 2>/dev/null || true)
+  LATEST_KERNEL=""
+  if command -v dnf >/dev/null 2>&1; then
+    LATEST_KERNEL=$(dnf -q list --showduplicates kernel 2>/dev/null | grep kernel.x86_64 | awk '{print $2}' | sort -V | tail -1)
+  fi
+}
+
 apply_sysctl() {
   local outfile="/etc/sysctl.d/90-fasterdata.conf"
   require_root
@@ -174,34 +286,16 @@ apply_sysctl() {
     cp -a "$outfile" "${outfile}.${timestamp}.bak" 2>/dev/null || true
     log_info "Backed up existing $outfile to ${outfile}.${timestamp}.bak"
   fi
-  # Scale recommended values based on max NIC speed
-  local max_speed_mbps
-  max_speed_mbps=$(get_max_link_speed)
-  log_info "Detected max link speed (Mbps): ${max_speed_mbps:-0}"
-
-  # Choose scaled recommendations
-  local rmem_max=536870912
-  local wmem_max=536870912
-  local default_backlog=250000
-  if (( max_speed_mbps >= 100000 )); then
-    # 100Gbps or higher: be more generous
-    rmem_max=1073741824
-    wmem_max=1073741824
-    default_backlog=500000
-  elif (( max_speed_mbps >= 40000 )); then
-    rmem_max=536870912
-    wmem_max=536870912
-    default_backlog=350000
-  fi
+  log_info "Detected max link speed (Mbps): ${MAX_LINK_SPEED:-0}"
 
   cat > "$outfile" <<EOF
 # Fasterdata-inspired tuning (https://fasterdata.es.net/)
 # Applied by fasterdata-tuning.sh
-net.core.rmem_max = ${rmem_max}
-net.core.wmem_max = ${wmem_max}
+net.core.rmem_max = ${SCALED_RMEM_MAX}
+net.core.wmem_max = ${SCALED_WMEM_MAX}
 net.core.rmem_default = 134217728
 net.core.wmem_default = 134217728
-net.core.netdev_max_backlog = ${default_backlog}
+net.core.netdev_max_backlog = ${SCALED_BACKLOG}
 net.core.default_qdisc = fq
 net.ipv4.tcp_rmem = 4096 87380 536870912
 net.ipv4.tcp_wmem = 4096 65536 536870912
@@ -225,58 +319,92 @@ EOF
 
 iface_audit() {
   local iface="$1"
-  printf "\nInterface: %s\n" "$iface"
-  ip -brief address show "$iface"
-
-  # Queue length
-  local txqlen
+  local state txqlen if_speed desired_txqlen qdisc driver
+  state=$(ip -o link show "$iface" 2>/dev/null | awk '{print $9}')
   txqlen=$(cat "/sys/class/net/$iface/tx_queue_len" 2>/dev/null || echo "?")
-  echo "  txqueuelen: $txqlen (rec: >= 10000)"
+  if_speed=$(get_iface_speed "$iface")
+  desired_txqlen=$(desired_txqlen_for_speed "$if_speed")
 
-  # speed
+  local speed_str="${if_speed}Mb/s"
   if command -v ethtool >/dev/null 2>&1; then
-    local s
-    s=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | tr -d '[:space:]' || true)
-    if [[ -n "$s" ]]; then
-      echo "  Speed: $s"
-    fi
+    local raw_speed
+    raw_speed=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | tr -d '[:space:]' || true)
+    [[ -n "$raw_speed" ]] && speed_str="$raw_speed"
   fi
 
-  # ethtool settings
+  qdisc=$(tc qdisc show dev "$iface" 2>/dev/null | head -n1 | awk '{print $2,$3,$4}')
+  driver="unknown"
   if command -v ethtool >/dev/null 2>&1; then
-    local offload
-    offload=$(ethtool -k "$iface" 2>/dev/null | grep -E 'gro:|gso:|tso:|rx-checksumming:|tx-checksumming:|lro:') || true
-    echo "  Offloads (current):"
-    # indent offload lines
-    if [[ -n "$offload" ]]; then
-      # indent offload lines (avoid external sed usage if empty)
-      if [[ -n "$offload" ]]; then
-        while IFS= read -r line; do
-          printf "    %s\n" "$line"
-        done <<<"$offload"
-      fi
-    fi
+    driver=$(ethtool -i "$iface" 2>/dev/null | awk -F': ' '/driver/ {print $2}') || true
+  fi
 
-    local rings
-    rings=$(ethtool -g "$iface" 2>/dev/null | sed 's/^/    /') || true
-    if [[ -n "$rings" ]]; then
-      echo "  Rings:"
-      echo "$rings"
+  local offload_devs offload_issue="ok"
+  if command -v ethtool >/dev/null 2>&1; then
+    offload_devs=$(ethtool -k "$iface" 2>/dev/null | grep -E 'gro:|gso:|tso:|rx-checksumming:|tx-checksumming:|lro:' || true)
+    if [[ "$offload_devs" =~ lro:[[:space:]]*on ]]; then
+      offload_issue="lro on"
     fi
-    # driver details
-    local drv
-    drv=$(ethtool -i "$iface" 2>/dev/null | awk -F': ' '/driver/ {print $2}') || true
-    if [[ -n "$drv" ]]; then
-      echo "  driver: $drv"
+    if ! echo "$offload_devs" | grep -q 'rx-checksumming:.*on'; then
+      offload_issue="rx csum off"
+    fi
+    if ! echo "$offload_devs" | grep -q 'tx-checksumming:.*on'; then
+      offload_issue="tx csum off"
     fi
   else
-    echo "  ethtool not installed; skipping offload/ring audit"
+    offload_issue="missing ethtool"
+    MISSING_TOOLS+=("ethtool (dnf install ethtool)")
   fi
 
-  # qdisc
-  local qdisc
-  qdisc=$(tc qdisc show dev "$iface" 2>/dev/null | head -n1 | awk '{print $2,$3,$4}')
-  echo "  qdisc: ${qdisc:-unknown} (rec: fq)"
+  local rings_cur rings_max rings_note=""
+  if command -v ethtool >/dev/null 2>&1; then
+    rings_cur=$(ethtool -g "$iface" 2>/dev/null | awk '/RX:/ {rx=$2} /TX:/ {tx=$2} END {print rx"/"tx}') || true
+    rings_max=$(ethtool -g "$iface" 2>/dev/null | awk '/RX max:/ {rx=$3} /TX max:/ {tx=$3} END {print rx"/"tx}') || true
+    if [[ -n "$rings_cur" && -n "$rings_max" && "$rings_max" =~ ^[0-9]+/[0-9]+$ && "$rings_cur" != "$rings_max" ]]; then
+      rings_note="rings $rings_cur (max $rings_max)"
+    fi
+  fi
+
+  local short_line="$(printf "%-12s state=%-7s speed=%-9s txqlen=%-6s(rec>=%-5s) qdisc=%-6s driver=%s" "$iface" "${state:-?}" "$speed_str" "$txqlen" "$desired_txqlen" "${qdisc:-?}" "$driver")"
+  printf "\n%s" "$short_line"
+  local offload_str="offload=${offload_issue}"
+  [[ -n "$rings_note" ]] && offload_str+=" $rings_note"
+  printf " %s\n" "$offload_str"
+
+  # Track issues for summary
+  local issues=()
+  if [[ "$txqlen" != "?" && "$txqlen" -lt "$desired_txqlen" ]]; then
+    issues+=("txqlen $txqlen<${desired_txqlen}")
+  fi
+  if [[ "${qdisc:-}" != "fq" ]]; then
+    issues+=("qdisc=${qdisc:-unknown}")
+  fi
+  if [[ "$offload_issue" != "ok" ]]; then
+    issues+=("$offload_issue")
+  fi
+  if [[ -n "$rings_note" ]]; then
+    issues+=("$rings_note")
+  fi
+  if (( ${#issues[@]} > 0 )); then
+    IF_ISSUES+=("$iface: ${issues[*]}")
+  fi
+
+  # Detailed log: capture full interface state
+  log_detail "==== Interface $iface ===="
+  log_detail "State: ${state:-unknown} Speed: $speed_str Driver: $driver"
+  log_detail "txqueuelen: $txqlen (rec >= $desired_txqlen)"
+  if command -v ip >/dev/null 2>&1; then
+    log_detail "$(ip -brief address show "$iface" 2>/dev/null)"
+  fi
+  if command -v ethtool >/dev/null 2>&1; then
+    log_detail "-- ethtool -k $iface --"
+    log_detail "$(ethtool -k "$iface" 2>/dev/null)"
+    log_detail "-- ethtool -g $iface --"
+    log_detail "$(ethtool -g "$iface" 2>/dev/null)"
+    log_detail "-- ethtool -i $iface --"
+    log_detail "$(ethtool -i "$iface" 2>/dev/null)"
+  fi
+  log_detail "-- tc qdisc show dev $iface --"
+  log_detail "$(tc qdisc show dev "$iface" 2>/dev/null)"
 }
 
 iface_apply() {
@@ -287,15 +415,11 @@ iface_apply() {
   if [[ -f /sys/class/net/$iface/tx_queue_len ]]; then
     local cur
     cur=$(cat "/sys/class/net/$iface/tx_queue_len")
-    # scale queue by link speed
+    # scale queue by link speed and target type
     local if_speed
     if_speed=$(get_iface_speed "$iface")
-    local desired_txqlen=10000
-    if (( if_speed >= 100000 )); then
-      desired_txqlen=20000
-    elif (( if_speed >= 40000 )); then
-      desired_txqlen=15000
-    fi
+    local desired_txqlen
+    desired_txqlen=$(desired_txqlen_for_speed "$if_speed")
     if [[ "$cur" -lt "$desired_txqlen" ]]; then
       ip link set dev "$iface" txqueuelen "$desired_txqlen"
     fi
@@ -322,9 +446,89 @@ iface_apply() {
   tc qdisc replace dev "$iface" root fq >/dev/null 2>&1 || true
 }
 
+create_ethtool_persist_service() {
+  # Generates systemd service to persist ethtool settings across reboots
+  local svcfile="/etc/systemd/system/ethtool-persist.service"
+  local dry_run=${1:-0}
+  require_root
+  
+  log_info "Generating $svcfile to persist ethtool settings"
+  
+  # Build list of ExecStart commands from applied ethtool changes
+  local exec_cmds=()
+  local iface
+  for iface in $(get_ifaces); do
+    if ! command -v ethtool >/dev/null 2>&1; then
+      continue
+    fi
+    
+    # Capture desired ring settings
+    local max_rx max_tx
+    max_rx=$(ethtool -g "$iface" 2>/dev/null | awk '/RX max:/ {print $3}' || true)
+    max_tx=$(ethtool -g "$iface" 2>/dev/null | awk '/TX max:/ {print $3}' || true)
+    if [[ -n "$max_rx" && -n "$max_tx" ]]; then
+      exec_cmds+=("ExecStart=/sbin/ethtool -G $iface rx $max_rx tx $max_tx")
+    fi
+    
+    # Capture offload settings (all on except LRO off)
+    exec_cmds+=("ExecStart=/sbin/ethtool -K $iface gro on gso on tso on rx on tx on lro off")
+    
+    # Capture txqueuelen
+    local txqlen
+    txqlen=$(cat "/sys/class/net/$iface/tx_queue_len" 2>/dev/null)
+    if [[ -n "$txqlen" && "$txqlen" != "?" ]]; then
+      exec_cmds+=("ExecStart=/sbin/ip link set dev $iface txqueuelen $txqlen")
+    fi
+  done
+  
+  # Show what would be written (always to log; to stdout if requested)
+  {
+    echo "[Unit]"
+    echo "Description=Persist ethtool settings (Fasterdata)"
+    echo "After=network.target"
+    echo "Wants=network.target"
+    echo ""
+    echo "[Service]"
+    echo "Type=oneshot"
+    for cmd in "${exec_cmds[@]}"; do
+      echo "$cmd"
+    done
+    echo "RemainAfterExit=yes"
+    echo ""
+    echo "[Install]"
+    echo "WantedBy=multi-user.target"
+  } | tee >(cat >>"$LOGFILE" 2>/dev/null)
+  
+  # Only write file if dry_run is 0
+  if [[ $dry_run -eq 0 ]]; then
+    {
+      echo "[Unit]"
+      echo "Description=Persist ethtool settings (Fasterdata)"
+      echo "After=network.target"
+      echo "Wants=network.target"
+      echo ""
+      echo "[Service]"
+      echo "Type=oneshot"
+      for cmd in "${exec_cmds[@]}"; do
+        echo "$cmd"
+      done
+      echo "RemainAfterExit=yes"
+      echo ""
+      echo "[Install]"
+      echo "WantedBy=multi-user.target"
+    } > "$svcfile"
+    
+    # Reload systemd and enable service
+    systemctl daemon-reload
+    systemctl enable ethtool-persist.service
+    log_info "Enabled ethtool-persist.service; to verify, run: systemctl status ethtool-persist"
+  fi
+}
+
 ensure_tuned_profile() {
   if ! command -v tuned-adm >/dev/null 2>&1; then
     log_warn "tuned-adm not installed; skipping tuned profile"
+    MISSING_TOOLS+=("tuned-adm (dnf install tuned)")
     return
   fi
   local active
@@ -360,6 +564,9 @@ check_cpu_governor() {
     log_warn "cpufreq not available or governor support missing; skipping governor check"
     return
   fi
+  if ! command -v cpupower >/dev/null 2>&1; then
+    MISSING_TOOLS+=("cpupower (dnf install kernel-tools)")
+  fi
   local governors
   governors=$(for cf in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do cat "$cf" 2>/dev/null || true; done | sort -u)
   echo "CPU governors: $governors"
@@ -370,23 +577,235 @@ check_cpu_governor() {
 
 check_iommu() {
   # Check kernel cmdline for IOMMU options
-  local cmdline
+  local cmdline cpu_vendor iommu_cmd
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
+  
+  # Detect CPU vendor (Intel vs AMD) per Fasterdata recommendations
+  if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="Intel"
+    iommu_cmd="intel_iommu=on iommu=pt"
+  elif grep -q '^vendor_id.*AuthenticAMD' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="AMD"
+    iommu_cmd="amd_iommu=on iommu=pt"
+  else
+    cpu_vendor="unknown"
+    iommu_cmd="iommu=pt (with intel_iommu=on or amd_iommu=on)"
+  fi
+  
   if echo "$cmdline" | grep -q -E 'intel_iommu=on|amd_iommu=on|iommu=pt|iommu=on'; then
     echo "IOMMU enabled via kernel command-line: $cmdline" | sed 's/^/  /'
   else
-    log_warn "IOMMU not enabled in kernel command-line (rec: intel_iommu=on or amd_iommu=on for SR-IOV/perf tuning)"
+    log_warn "IOMMU not enabled in kernel command-line (CPU: $cpu_vendor, rec: $iommu_cmd for SR-IOV/perf tuning)"
+    echo "IOMMU setup: Edit GRUB configuration to enable IOMMU (per Fasterdata):"
+    echo "  1. Edit /etc/default/grub"
+    echo "  2. Add to GRUB_CMDLINE_LINUX: $iommu_cmd"
+    echo "  3. Example: GRUB_CMDLINE_LINUX=\"root=... $iommu_cmd ...\""
+    echo "  4. Regenerate GRUB: grub2-mkconfig -o /boot/grub2/grub.cfg"
+    echo "  5. Reboot the system for changes to take effect"
+    echo "  6. Verify with: cat /proc/cmdline (should show iommu=pt)"
   fi
 }
 
+print_host_info() {
+  local os_release kernel_ver mem_info_str fqdn smt_status cpu_info cpu_vendor
+  os_release=$(awk -F'=' '/^PRETTY_NAME/ {print $2}' /etc/os-release 2>/dev/null | tr -d '"')
+  kernel_ver=$(uname -r)
+  fqdn=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "unknown")
+  local mem_total_kb
+  mem_total_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null)
+  if [[ -n "$mem_total_kb" ]]; then
+    local mem_gb=$((mem_total_kb / 1024 / 1024))
+    mem_info_str="${mem_gb} GiB"
+  else
+    mem_info_str="unknown"
+  fi
+  
+  # Get CPU info
+  local cpu_count cpu_model cpu_mhz
+  cpu_count=$(grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo "unknown")
+  if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="Intel"
+  elif grep -q '^vendor_id.*AuthenticAMD' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="AMD"
+  else
+    cpu_vendor="unknown"
+  fi
+  cpu_model=$(awk -F':' '/^model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null | xargs)
+  # Extract CPU clock speed from /proc/cpuinfo (try cpu MHz first, fallback to max freq)
+  cpu_mhz=$(awk -F':' '/^cpu MHz/ {print int($2); exit}' /proc/cpuinfo 2>/dev/null)
+  if [[ -z "$cpu_mhz" ]] || [[ "$cpu_mhz" -eq 0 ]]; then
+    # Try /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq (in kHz)
+    local max_freq_khz
+    max_freq_khz=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq 2>/dev/null)
+    if [[ -n "$max_freq_khz" ]]; then
+      cpu_mhz=$((max_freq_khz / 1000))
+    fi
+  fi
+  local cpu_speed_str=""
+  if [[ -n "$cpu_mhz" ]] && [[ "$cpu_mhz" -gt 0 ]]; then
+    # Convert MHz to GHz using bash arithmetic
+    local cpu_ghz_int=$((cpu_mhz / 1000))
+    local cpu_ghz_frac=$(((cpu_mhz % 1000 + 50) / 100))  # Round to 1 decimal place
+    cpu_speed_str=" @ ${cpu_ghz_int}.${cpu_ghz_frac} GHz"
+  fi
+  if [[ -n "$cpu_model" ]]; then
+    cpu_info="$cpu_count cores, $cpu_vendor: $cpu_model$cpu_speed_str"
+  else
+    cpu_info="$cpu_count cores, $cpu_vendor$cpu_speed_str"
+  fi
+  
+  # Check SMT status
+  if [[ -r /sys/devices/system/cpu/smt/control ]]; then
+    smt_status=$(cat /sys/devices/system/cpu/smt/control)
+    if [[ "$smt_status" == "on" ]]; then
+      smt_status="$(colorize green "on")"
+    else
+      smt_status="$(colorize yellow "$smt_status")"
+    fi
+  else
+    smt_status="not available"
+  fi
+  
+  echo "Host Info:"
+  echo "  FQDN: $fqdn"
+  echo "  OS: ${os_release:-unknown}"
+  echo "  Kernel: $kernel_ver"
+  echo "  Memory: $mem_info_str"
+  echo "  CPUs: $cpu_info"
+  echo "  SMT: $smt_status"
+}
+
+check_smt() {
+  if [[ ! -r /sys/devices/system/cpu/smt/control ]]; then
+    log_detail "SMT control not available on this system"
+    return
+  fi
+  local smt_status
+  smt_status=$(cat /sys/devices/system/cpu/smt/control)
+  log_detail "SMT status: $smt_status"
+  
+  if [[ "$smt_status" != "on" ]]; then
+    log_warn "SMT is currently $smt_status (recommendation: on for measurement hosts; off for low-latency/isolated workloads)"
+    echo "SMT control: to enable, run: echo on | sudo tee /sys/devices/system/cpu/smt/control"
+    echo "SMT control: to disable, run: echo off | sudo tee /sys/devices/system/cpu/smt/control"
+  fi
+}
+
+driver_vendor_hint() {
+  case "$1" in
+    mlx5_core|mlx4_en|mlx4_core) echo "Mellanox/NVIDIA";;
+    bnxt_en|tg3|bnx2x|bnx2) echo "Broadcom";;
+    ixgbe|i40e|ice|e1000e|igb) echo "Intel";;
+    *) echo "Other";;
+  esac
+}
+
 check_drivers() {
+  if ! command -v ethtool >/dev/null 2>&1; then
+    log_warn "ethtool not installed; skipping driver version checks"
+    MISSING_TOOLS+=("ethtool (dnf install ethtool)")
+    return
+  fi
+
+  local -A vendor_hint_seen=()
+  local kernel_hint_added=0
+  echo "Driver info:"
   for iface in $(get_ifaces); do
-    if command -v ethtool >/dev/null 2>&1; then
-      local drv
-      drv=$(ethtool -i "$iface" 2>/dev/null | awk -F': ' '/driver/ {print $2}') || true
-      echo "Interface $iface uses driver: ${drv:-unknown}"
+    local info
+    info=$(ethtool -i "$iface" 2>/dev/null)
+    local drv version fw bus
+    drv=$(awk -F': ' '/driver:/ {print $2}' <<<"$info")
+    version=$(awk -F': ' '/version:/ {print $2}' <<<"$info")
+    fw=$(awk -F': ' '/firmware-version:/ {print $2}' <<<"$info")
+    bus=$(awk -F': ' '/bus-info:/ {print $2}' <<<"$info")
+    local vendor
+    vendor=$(driver_vendor_hint "$drv")
+    local modpath pkg pkgver
+    modpath=$(modinfo -n "$drv" 2>/dev/null || true)
+    pkg=$(rpm -q --whatprovides "$modpath" 2>/dev/null | head -n1 || true)
+
+    log_detail "Driver $iface: driver=$drv version=${version:-unknown} firmware=${fw:-unknown} vendor=${vendor:-unknown} pkg=${pkg:-unknown} bus=${bus:-unknown}"
+    echo "  $iface: driver=$drv version=${version:-unknown} firmware=${fw:-unknown} vendor=${vendor:-unknown} pkg=${pkg:-unknown}"
+
+    local kernel_hint=""
+    if [[ -n "$LATEST_KERNEL" && -n "$RUNNING_KERNEL" ]]; then
+      local latest_base="${LATEST_KERNEL%.x86_64}"
+      local running_base="${RUNNING_KERNEL%.x86_64}"
+      if [[ "$latest_base" != "$running_base" ]]; then
+        kernel_hint="Kernel update available: dnf update kernel && reboot (current: $RUNNING_KERNEL, latest: $LATEST_KERNEL)."
+      fi
+    fi
+
+    local vendor_hint=""
+    case "$vendor" in
+      "Mellanox/NVIDIA") vendor_hint="For ConnectX/mlx5, keep kernel+linux-firmware current or use NVIDIA OFED if required (see https://network.nvidia.com/products/ethernet-drivers/).";;
+      "Broadcom") vendor_hint="Broadcom NICs track the distro kernel; keep kernel+linux-firmware current and use vendor firmware tools (e.g., bnxtnvm) when available.";;
+      "Intel") vendor_hint="Intel NICs track the distro kernel; update kernel+linux-firmware for latest drivers/firmware blobs.";;
+      *) vendor_hint="Keep kernel+linux-firmware current for latest in-kernel drivers.";;
+    esac
+
+    if [[ -n "$kernel_hint" && $kernel_hint_added -eq 0 ]]; then
+      DRIVER_UPDATES+=("$kernel_hint")
+      kernel_hint_added=1
+    fi
+    if [[ -n "$vendor_hint" && -z "${vendor_hint_seen[$vendor]+x}" ]]; then
+      DRIVER_UPDATES+=("$vendor_hint")
+      vendor_hint_seen[$vendor]=1
     fi
   done
+}
+
+print_summary() {
+  printf "\nSummary:\n"
+  echo "- Target type: $TARGET_TYPE"
+  echo "- Sysctl mismatches: $SYSCTL_MISMATCHES"
+  if (( ${#IF_ISSUES[@]} > 0 )); then
+    echo "- Interfaces needing attention (${#IF_ISSUES[@]}):"
+    for item in "${IF_ISSUES[@]}"; do
+      echo "  * $item"
+    done
+  else
+    echo "- Interfaces needing attention: none"
+  fi
+
+  if (( ${#DRIVER_UPDATES[@]} > 0 )); then
+    local -A seen_drv=()
+    local unique_drv=()
+    for t in "${DRIVER_UPDATES[@]}"; do
+      if [[ -z "${seen_drv[$t]+x}" ]]; then
+        seen_drv[$t]=1
+        unique_drv+=("$t")
+      fi
+    done
+    echo "- Driver/version actions:"
+    for t in "${unique_drv[@]}"; do
+      echo "  * $t"
+    done
+  else
+    echo "- Driver/version actions: none"
+  fi
+
+  if (( ${#MISSING_TOOLS[@]} > 0 )); then
+    # de-duplicate
+    local -A seen=()
+    local unique=()
+    for t in "${MISSING_TOOLS[@]}"; do
+      if [[ -z "${seen[$t]+x}" ]]; then
+        seen[$t]=1
+        unique+=("$t")
+      fi
+    done
+    echo "- Install these tools for best results:"
+    for t in "${unique[@]}"; do
+      echo "  * $t"
+    done
+  else
+    echo "- Required tools: present"
+  fi
+
+  if [[ -n "$LOGFILE" ]]; then
+    echo "- Detailed log: $LOGFILE"
+  fi
 }
 
 main() {
@@ -394,10 +813,21 @@ main() {
     case "$1" in
       --mode) MODE="$2"; shift 2;;
       --ifaces) IFACES="$2"; shift 2;;
+      --target) TARGET_TYPE="$2"; shift 2;;
+      --color) USE_COLOR=1; shift;;
       -h|--help) usage; exit 0;;
       *) echo "Unknown arg: $1" >&2; usage; exit 1;;
     esac
   done
+
+  if [[ "$TARGET_TYPE" != "measurement" && "$TARGET_TYPE" != "dtn" ]]; then
+    echo "ERROR: --target must be measurement or dtn" >&2
+    exit 1
+  fi
+
+  init_log
+  set_speed_scaled_recs
+  cache_kernel_versions
 
   if [[ "$MODE" != "audit" && "$MODE" != "apply" ]]; then
     echo "ERROR: --mode must be audit or apply" >&2; exit 1
@@ -405,6 +835,7 @@ main() {
   [[ "$MODE" == "apply" ]] && require_root
 
   if [[ "$MODE" == "audit" ]]; then
+    print_host_info
     print_sysctl_diff
   else
     if ! has_bbr; then
@@ -430,14 +861,18 @@ main() {
   if [[ "$MODE" == "audit" ]]; then
     check_cpu_governor
     check_iommu
+    check_smt
     check_drivers
   fi
 
   if [[ "$MODE" == "apply" ]]; then
+    create_ethtool_persist_service
     log_info "Apply complete. Consider rebooting or rerunning audit to confirm settings."
   else
     log_info "Audit complete. Entries marked with '*' differ from recommended values."
   fi
+
+  print_summary
 }
 
 main "$@"

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
@@ -167,6 +167,13 @@ apply_sysctl() {
   local outfile="/etc/sysctl.d/90-fasterdata.conf"
   require_root
   log_info "Writing $outfile"
+  # backup existing file
+  if [[ -f "$outfile" ]]; then
+    local timestamp
+    timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+    cp -a "$outfile" "${outfile}.${timestamp}.bak" 2>/dev/null || true
+    log_info "Backed up existing $outfile to ${outfile}.${timestamp}.bak"
+  fi
   # Scale recommended values based on max NIC speed
   local max_speed_mbps
   max_speed_mbps=$(get_max_link_speed)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - 'nftables': 'features/nftables.md'
   - Tools & Scripts:
     - 'Scripts and tools': 'perfsonar/tools_scripts/README.md'
+    - 'Fasterdata host tuning (EL9)': 'perfsonar/tools_scripts/fasterdata-tuning.md'
     - 'Compose bundle (docker-compose.yml)': 'perfsonar/tools_scripts/docker-compose.yml'
     - 'LS registration updater (script)': 'perfsonar/tools_scripts/perfSONAR-update-lsregistration.sh'
     - 'LS registration helpers (README)': 'perfsonar/tools_scripts/README-lsregistration.md'

--- a/site/perfsonar/tools_scripts/fasterdata-tuning.sh
+++ b/site/perfsonar/tools_scripts/fasterdata-tuning.sh
@@ -1,0 +1,878 @@
+#!/usr/bin/env bash
+# fasterdata-tuning.sh
+# --------------------
+# Audit and optionally apply host/network tuning recommended by ESnet Fasterdata
+# for high-throughput hosts (EL9 focus). Defaults to audit-only.
+#
+# Sources: https://fasterdata.es.net/host-tuning/ , /network-tuning/ , /DTN/
+#
+# Modes:
+#   --mode audit   (default)  -> read current settings, show differences
+#   --mode apply               -> apply recommended values (requires root)
+#
+# Scope:
+#   - Sysctl networking parameters (buffers, congestion control, qdisc)
+#   - Tuned profile suggestion (network-throughput)
+#   - Per-interface checks: GRO/TSO/GSO/checksums, LRO off, ring buffers to max,
+#     txqueuelen, qdisc fq
+#
+# Notes:
+#   - Uses conservative recommendations suitable for perfSONAR/DTN-style hosts on EL9.
+#   - Apply mode writes /etc/sysctl.d/90-fasterdata.conf and applies live settings.
+#   - ethtool changes are immediate but not persisted across reboots; consider
+#     running this script from a boot-time unit if persistence is required.
+
+set -euo pipefail
+# Ignore SIGPIPE to avoid non-zero exits when output is piped/truncated
+trap '' PIPE
+
+LOGFILE=${LOGFILE:-/tmp/fasterdata-tuning-$(date -u +%Y%m%dT%H%M%SZ).log}
+SYSCTL_MISMATCHES=0
+MISSING_TOOLS=()
+IF_ISSUES=()
+DRIVER_UPDATES=()
+TARGET_TYPE="measurement"
+MAX_LINK_SPEED=0
+SCALED_RMEM_MAX=536870912
+SCALED_WMEM_MAX=536870912
+SCALED_BACKLOG=250000
+RUNNING_KERNEL=""
+LATEST_KERNEL=""
+USE_COLOR=0
+
+# Color codes for terminal output
+readonly C_GREEN='\033[0;32m'
+readonly C_YELLOW='\033[0;33m'
+readonly C_RED='\033[0;31m'
+readonly C_RESET='\033[0m'
+
+MODE="audit"
+IFACES=""
+
+usage() {
+  cat <<'EOF'
+Usage: fasterdata-tuning.sh [--mode audit|apply] [--ifaces "eth0,eth1"] [--target measurement|dtn] [--color] [--verbose]
+
+Modes:
+  audit   (default) Show current values vs. Fasterdata recommendations
+  apply             Apply recommended values (requires root)
+
+Options:
+  --ifaces LIST     Comma-separated interfaces to check/tune. Default: all up, non-loopback
+  --target TYPE     Host type: measurement (default) or dtn (data transfer node)
+  --color           Use color codes (green=ok, yellow=warning, red=critical)
+  --verbose         More detail in audit output
+  -h, --help        Show this help
+EOF
+}
+
+init_log() {
+  if [[ -z "$LOGFILE" ]]; then
+    log_warn "LOGFILE is empty; detailed logging disabled"
+    return
+  fi
+  if : >"$LOGFILE" 2>/dev/null; then
+    log_info "Detailed log: $LOGFILE"
+  else
+    log_warn "Cannot write log file $LOGFILE; disabling detailed log"
+    LOGFILE=""
+  fi
+}
+
+log() { echo "$*"; }
+log_warn() { echo "[WARN] $*" >&2; }
+log_info() { echo "[INFO] $*"; }
+
+colorize() {
+  local level="$1" text="$2"
+  [[ $USE_COLOR -eq 0 ]] && { echo "$text"; return; }
+  case "$level" in
+    green) echo -e "${C_GREEN}${text}${C_RESET}";;
+    yellow) echo -e "${C_YELLOW}${text}${C_RESET}";;
+    red) echo -e "${C_RED}${text}${C_RESET}";;
+    *) echo "$text";;
+  esac
+}
+
+log_detail() {
+  [[ -z "$LOGFILE" ]] && return
+  printf "%s\n" "$*" >>"$LOGFILE" 2>/dev/null || true
+}
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: --mode apply requires root" >&2
+    exit 1
+  fi
+}
+
+# Recommended sysctl values (Fasterdata-inspired, EL9 context)
+declare -A SYSCTL_RECS=(
+  [net.core.rmem_max]=536870912
+  [net.core.wmem_max]=536870912
+  [net.core.rmem_default]=134217728
+  [net.core.wmem_default]=134217728
+  [net.core.netdev_max_backlog]=250000
+  [net.core.default_qdisc]=fq
+  [net.ipv4.tcp_rmem]="4096 87380 536870912"
+  [net.ipv4.tcp_wmem]="4096 65536 536870912"
+  [net.ipv4.tcp_congestion_control]=bbr
+  [net.ipv4.tcp_mtu_probing]=1
+  [net.ipv4.tcp_window_scaling]=1
+  [net.ipv4.tcp_timestamps]=1
+  [net.ipv4.tcp_sack]=1
+  [net.ipv4.tcp_low_latency]=0
+)
+
+has_bbr() {
+  sysctl -n net.ipv4.tcp_available_congestion_control 2>/dev/null | grep -qw bbr
+}
+
+get_ifaces() {
+  if [[ -n "$IFACES" ]]; then
+    echo "$IFACES" | tr ',' ' '
+    return
+  fi
+
+  # prefer physical NICs under /sys/class/net/<iface>/device (PCI devices)
+  local _path iface
+  # Collect candidate interfaces, preferring physical PCI devices, even if link is down
+  local candidates=()
+  for _path in /sys/class/net/*; do
+    iface=$(basename "$_path")
+    # filter common virtual interface prefixes
+    if [[ "$iface" =~ ^(lo|docker|cni|veth|br-|virbr|vmnet|vnet|ovs-) ]]; then
+      continue
+    fi
+    if [[ -d "/sys/class/net/$iface/device" ]]; then
+      candidates+=("$iface")
+      continue
+    fi
+    # fall back: include interfaces with carrier/link detected (up or carrier)
+    if ip -o link show "$iface" 2>/dev/null | grep -q 'state UP'; then
+      candidates+=("$iface")
+      continue
+    fi
+    if command -v ethtool >/dev/null 2>&1; then
+      if ethtool "$iface" 2>/dev/null | grep -q 'Link detected: yes'; then
+        candidates+=("$iface")
+      fi
+    fi
+  done
+
+  # De-duplicate and print
+  if [[ ${#candidates[@]} -gt 0 ]]; then
+    printf "%s\n" "${candidates[@]}" | sort -u
+  fi
+}
+
+desired_txqlen_for_speed() {
+  local speed_mbps="$1"
+  local base=10000
+  [[ "$TARGET_TYPE" == "dtn" ]] && base=12000
+  if (( speed_mbps >= 100000 )); then
+    [[ "$TARGET_TYPE" == "dtn" ]] && base=25000 || base=20000
+  elif (( speed_mbps >= 40000 )); then
+    [[ "$TARGET_TYPE" == "dtn" ]] && base=18000 || base=15000
+  fi
+  echo "$base"
+}
+
+print_sysctl_diff() {
+  local key wanted current status
+  log_detail "Sysctl audit (current vs recommended)"
+  printf "\nSysctl audit (current vs recommended)\n"
+  printf "%-35s %-35s %-35s\n" "Key" "Current" "Recommended"
+  printf '%0.105s\n' "-------------------------------------------------------------------------------------------------"
+  for key in "${!SYSCTL_RECS[@]}"; do
+    wanted=${SYSCTL_RECS[$key]}
+    current=$(sysctl -n "$key" 2>/dev/null || echo "(unset)")
+    status=""
+    if [[ "$current" != "$wanted" ]]; then
+      status="*"
+      ((SYSCTL_MISMATCHES+=1))
+      log_detail "SYSCTL mismatch: $key current='$current' recommended='$wanted'"
+    else
+      log_detail "SYSCTL ok: $key=$current"
+    fi
+    printf "%-35s %-35s %-35s %s\n" "$key" "$current" "$wanted" "$status"
+  done
+}
+
+get_max_link_speed() {
+  # returns max link speed in Mbps across candidate interfaces
+  local max=0
+  for iface in $(get_ifaces); do
+    if command -v ethtool >/dev/null 2>&1; then
+      local s
+      s=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | tr -d '[:space:]') || continue
+      # s often like '100Gb/s' or '1000Mb/s' or 'Unknown!'
+      if [[ "$s" =~ ^([0-9]+)(G|M)b/s$ ]]; then
+        local val=${BASH_REMATCH[1]}
+        local unit=${BASH_REMATCH[2]}
+        if [[ "$unit" == "G" ]]; then
+          val=$((val * 1000))
+        fi
+        if (( val > max )); then max=$val; fi
+      fi
+    fi
+  done
+  echo "$max"
+}
+
+get_iface_speed() {
+  local iface="$1"
+  if ! command -v ethtool >/dev/null 2>&1; then
+    echo 0
+    return
+  fi
+  local s
+  s=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | tr -d '[:space:]' || true)
+  if [[ "$s" =~ ^([0-9]+)(G|M)b/s$ ]]; then
+    local val=${BASH_REMATCH[1]}
+    local unit=${BASH_REMATCH[2]}
+    if [[ "$unit" == "G" ]]; then
+      echo $((val * 1000))
+    else
+      echo "$val"
+    fi
+  else
+    echo 0
+  fi
+}
+
+set_speed_scaled_recs() {
+  MAX_LINK_SPEED=$(get_max_link_speed)
+  SCALED_RMEM_MAX=536870912
+  SCALED_WMEM_MAX=536870912
+  SCALED_BACKLOG=250000
+  if (( MAX_LINK_SPEED >= 100000 )); then
+    SCALED_RMEM_MAX=1073741824
+    SCALED_WMEM_MAX=1073741824
+    SCALED_BACKLOG=500000
+  elif (( MAX_LINK_SPEED >= 40000 )); then
+    SCALED_RMEM_MAX=536870912
+    SCALED_WMEM_MAX=536870912
+    SCALED_BACKLOG=350000
+  fi
+  if [[ "$TARGET_TYPE" == "dtn" ]]; then
+    if (( MAX_LINK_SPEED >= 100000 )); then
+      SCALED_BACKLOG=600000
+    elif (( MAX_LINK_SPEED >= 40000 )); then
+      SCALED_BACKLOG=400000
+    fi
+  fi
+  SYSCTL_RECS[net.core.rmem_max]=$SCALED_RMEM_MAX
+  SYSCTL_RECS[net.core.wmem_max]=$SCALED_WMEM_MAX
+  SYSCTL_RECS[net.core.netdev_max_backlog]=$SCALED_BACKLOG
+}
+
+cache_kernel_versions() {
+  RUNNING_KERNEL=$(uname -r 2>/dev/null || true)
+  LATEST_KERNEL=""
+  if command -v dnf >/dev/null 2>&1; then
+    LATEST_KERNEL=$(dnf -q list --showduplicates kernel 2>/dev/null | grep kernel.x86_64 | awk '{print $2}' | sort -V | tail -1)
+  fi
+}
+
+apply_sysctl() {
+  local outfile="/etc/sysctl.d/90-fasterdata.conf"
+  require_root
+  log_info "Writing $outfile"
+  # backup existing file
+  if [[ -f "$outfile" ]]; then
+    local timestamp
+    timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+    cp -a "$outfile" "${outfile}.${timestamp}.bak" 2>/dev/null || true
+    log_info "Backed up existing $outfile to ${outfile}.${timestamp}.bak"
+  fi
+  log_info "Detected max link speed (Mbps): ${MAX_LINK_SPEED:-0}"
+
+  cat > "$outfile" <<EOF
+# Fasterdata-inspired tuning (https://fasterdata.es.net/)
+# Applied by fasterdata-tuning.sh
+net.core.rmem_max = ${SCALED_RMEM_MAX}
+net.core.wmem_max = ${SCALED_WMEM_MAX}
+net.core.rmem_default = 134217728
+net.core.wmem_default = 134217728
+net.core.netdev_max_backlog = ${SCALED_BACKLOG}
+net.core.default_qdisc = fq
+net.ipv4.tcp_rmem = 4096 87380 536870912
+net.ipv4.tcp_wmem = 4096 65536 536870912
+net.ipv4.tcp_congestion_control = bbr
+net.ipv4.tcp_mtu_probing = 1
+net.ipv4.tcp_window_scaling = 1
+net.ipv4.tcp_timestamps = 1
+net.ipv4.tcp_sack = 1
+net.ipv4.tcp_low_latency = 0
+EOF
+  if ! has_bbr; then
+    log_warn "bbr not available; falling back to cubic at runtime (file still sets bbr)"
+  fi
+  log_info "Applying sysctl settings"
+  sysctl --system >/dev/null
+  # If bbr missing, set congestion control to cubic live to avoid failure
+  if ! has_bbr; then
+    sysctl -w net.ipv4.tcp_congestion_control=cubic >/dev/null
+  fi
+}
+
+iface_audit() {
+  local iface="$1"
+  local state txqlen if_speed desired_txqlen qdisc driver
+  state=$(ip -o link show "$iface" 2>/dev/null | awk '{print $9}')
+  txqlen=$(cat "/sys/class/net/$iface/tx_queue_len" 2>/dev/null || echo "?")
+  if_speed=$(get_iface_speed "$iface")
+  desired_txqlen=$(desired_txqlen_for_speed "$if_speed")
+
+  local speed_str="${if_speed}Mb/s"
+  if command -v ethtool >/dev/null 2>&1; then
+    local raw_speed
+    raw_speed=$(ethtool "$iface" 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | tr -d '[:space:]' || true)
+    [[ -n "$raw_speed" ]] && speed_str="$raw_speed"
+  fi
+
+  qdisc=$(tc qdisc show dev "$iface" 2>/dev/null | head -n1 | awk '{print $2,$3,$4}')
+  driver="unknown"
+  if command -v ethtool >/dev/null 2>&1; then
+    driver=$(ethtool -i "$iface" 2>/dev/null | awk -F': ' '/driver/ {print $2}') || true
+  fi
+
+  local offload_devs offload_issue="ok"
+  if command -v ethtool >/dev/null 2>&1; then
+    offload_devs=$(ethtool -k "$iface" 2>/dev/null | grep -E 'gro:|gso:|tso:|rx-checksumming:|tx-checksumming:|lro:' || true)
+    if [[ "$offload_devs" =~ lro:[[:space:]]*on ]]; then
+      offload_issue="lro on"
+    fi
+    if ! echo "$offload_devs" | grep -q 'rx-checksumming:.*on'; then
+      offload_issue="rx csum off"
+    fi
+    if ! echo "$offload_devs" | grep -q 'tx-checksumming:.*on'; then
+      offload_issue="tx csum off"
+    fi
+  else
+    offload_issue="missing ethtool"
+    MISSING_TOOLS+=("ethtool (dnf install ethtool)")
+  fi
+
+  local rings_cur rings_max rings_note=""
+  if command -v ethtool >/dev/null 2>&1; then
+    rings_cur=$(ethtool -g "$iface" 2>/dev/null | awk '/RX:/ {rx=$2} /TX:/ {tx=$2} END {print rx"/"tx}') || true
+    rings_max=$(ethtool -g "$iface" 2>/dev/null | awk '/RX max:/ {rx=$3} /TX max:/ {tx=$3} END {print rx"/"tx}') || true
+    if [[ -n "$rings_cur" && -n "$rings_max" && "$rings_max" =~ ^[0-9]+/[0-9]+$ && "$rings_cur" != "$rings_max" ]]; then
+      rings_note="rings $rings_cur (max $rings_max)"
+    fi
+  fi
+
+  local short_line="$(printf "%-12s state=%-7s speed=%-9s txqlen=%-6s(rec>=%-5s) qdisc=%-6s driver=%s" "$iface" "${state:-?}" "$speed_str" "$txqlen" "$desired_txqlen" "${qdisc:-?}" "$driver")"
+  printf "\n%s" "$short_line"
+  local offload_str="offload=${offload_issue}"
+  [[ -n "$rings_note" ]] && offload_str+=" $rings_note"
+  printf " %s\n" "$offload_str"
+
+  # Track issues for summary
+  local issues=()
+  if [[ "$txqlen" != "?" && "$txqlen" -lt "$desired_txqlen" ]]; then
+    issues+=("txqlen $txqlen<${desired_txqlen}")
+  fi
+  if [[ "${qdisc:-}" != "fq" ]]; then
+    issues+=("qdisc=${qdisc:-unknown}")
+  fi
+  if [[ "$offload_issue" != "ok" ]]; then
+    issues+=("$offload_issue")
+  fi
+  if [[ -n "$rings_note" ]]; then
+    issues+=("$rings_note")
+  fi
+  if (( ${#issues[@]} > 0 )); then
+    IF_ISSUES+=("$iface: ${issues[*]}")
+  fi
+
+  # Detailed log: capture full interface state
+  log_detail "==== Interface $iface ===="
+  log_detail "State: ${state:-unknown} Speed: $speed_str Driver: $driver"
+  log_detail "txqueuelen: $txqlen (rec >= $desired_txqlen)"
+  if command -v ip >/dev/null 2>&1; then
+    log_detail "$(ip -brief address show "$iface" 2>/dev/null)"
+  fi
+  if command -v ethtool >/dev/null 2>&1; then
+    log_detail "-- ethtool -k $iface --"
+    log_detail "$(ethtool -k "$iface" 2>/dev/null)"
+    log_detail "-- ethtool -g $iface --"
+    log_detail "$(ethtool -g "$iface" 2>/dev/null)"
+    log_detail "-- ethtool -i $iface --"
+    log_detail "$(ethtool -i "$iface" 2>/dev/null)"
+  fi
+  log_detail "-- tc qdisc show dev $iface --"
+  log_detail "$(tc qdisc show dev "$iface" 2>/dev/null)"
+}
+
+iface_apply() {
+  local iface="$1"
+  log_info "Tuning interface $iface"
+
+  # txqueuelen
+  if [[ -f /sys/class/net/$iface/tx_queue_len ]]; then
+    local cur
+    cur=$(cat "/sys/class/net/$iface/tx_queue_len")
+    # scale queue by link speed and target type
+    local if_speed
+    if_speed=$(get_iface_speed "$iface")
+    local desired_txqlen
+    desired_txqlen=$(desired_txqlen_for_speed "$if_speed")
+    if [[ "$cur" -lt "$desired_txqlen" ]]; then
+      ip link set dev "$iface" txqueuelen "$desired_txqlen"
+    fi
+  fi
+
+  if command -v ethtool >/dev/null 2>&1; then
+    # Rings: set to max where available
+    local max_rx max_tx
+    max_rx=$(ethtool -g "$iface" 2>/dev/null | awk '/RX:/ {rx=$2} /RX max:/ {rxmax=$3} END {if(rxmax>0) print rxmax}' || true)
+    max_tx=$(ethtool -g "$iface" 2>/dev/null | awk '/TX:/ {tx=$2} /TX max:/ {txmax=$3} END {if(txmax>0) print txmax}' || true)
+    if [[ -n "$max_rx" ]]; then
+      ethtool -G "$iface" rx "$max_rx" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$max_tx" ]]; then
+      ethtool -G "$iface" tx "$max_tx" >/dev/null 2>&1 || true
+    fi
+
+    # Offloads: enable GRO/GSO/TSO, checksums; disable LRO
+    ethtool -K "$iface" gro on gso on tso on rx on tx on >/dev/null 2>&1 || true
+    ethtool -K "$iface" lro off >/dev/null 2>&1 || true
+  fi
+
+  # qdisc fq
+  tc qdisc replace dev "$iface" root fq >/dev/null 2>&1 || true
+}
+
+create_ethtool_persist_service() {
+  # Generates systemd service to persist ethtool settings across reboots
+  local svcfile="/etc/systemd/system/ethtool-persist.service"
+  local dry_run=${1:-0}
+  require_root
+  
+  log_info "Generating $svcfile to persist ethtool settings"
+  
+  # Build list of ExecStart commands from applied ethtool changes
+  local exec_cmds=()
+  local iface
+  for iface in $(get_ifaces); do
+    if ! command -v ethtool >/dev/null 2>&1; then
+      continue
+    fi
+    
+    # Capture desired ring settings
+    local max_rx max_tx
+    max_rx=$(ethtool -g "$iface" 2>/dev/null | awk '/RX max:/ {print $3}' || true)
+    max_tx=$(ethtool -g "$iface" 2>/dev/null | awk '/TX max:/ {print $3}' || true)
+    if [[ -n "$max_rx" && -n "$max_tx" ]]; then
+      exec_cmds+=("ExecStart=/sbin/ethtool -G $iface rx $max_rx tx $max_tx")
+    fi
+    
+    # Capture offload settings (all on except LRO off)
+    exec_cmds+=("ExecStart=/sbin/ethtool -K $iface gro on gso on tso on rx on tx on lro off")
+    
+    # Capture txqueuelen
+    local txqlen
+    txqlen=$(cat "/sys/class/net/$iface/tx_queue_len" 2>/dev/null)
+    if [[ -n "$txqlen" && "$txqlen" != "?" ]]; then
+      exec_cmds+=("ExecStart=/sbin/ip link set dev $iface txqueuelen $txqlen")
+    fi
+  done
+  
+  # Show what would be written (always to log; to stdout if requested)
+  {
+    echo "[Unit]"
+    echo "Description=Persist ethtool settings (Fasterdata)"
+    echo "After=network.target"
+    echo "Wants=network.target"
+    echo ""
+    echo "[Service]"
+    echo "Type=oneshot"
+    for cmd in "${exec_cmds[@]}"; do
+      echo "$cmd"
+    done
+    echo "RemainAfterExit=yes"
+    echo ""
+    echo "[Install]"
+    echo "WantedBy=multi-user.target"
+  } | tee >(cat >>"$LOGFILE" 2>/dev/null)
+  
+  # Only write file if dry_run is 0
+  if [[ $dry_run -eq 0 ]]; then
+    {
+      echo "[Unit]"
+      echo "Description=Persist ethtool settings (Fasterdata)"
+      echo "After=network.target"
+      echo "Wants=network.target"
+      echo ""
+      echo "[Service]"
+      echo "Type=oneshot"
+      for cmd in "${exec_cmds[@]}"; do
+        echo "$cmd"
+      done
+      echo "RemainAfterExit=yes"
+      echo ""
+      echo "[Install]"
+      echo "WantedBy=multi-user.target"
+    } > "$svcfile"
+    
+    # Reload systemd and enable service
+    systemctl daemon-reload
+    systemctl enable ethtool-persist.service
+    log_info "Enabled ethtool-persist.service; to verify, run: systemctl status ethtool-persist"
+  fi
+}
+
+ensure_tuned_profile() {
+  if ! command -v tuned-adm >/dev/null 2>&1; then
+    log_warn "tuned-adm not installed; skipping tuned profile"
+    MISSING_TOOLS+=("tuned-adm (dnf install tuned)")
+    return
+  fi
+  local active
+  active=$(tuned-adm active 2>/dev/null | awk '{print $3}' || true)
+  if [[ "$MODE" == "audit" ]]; then
+    echo "tuned-adm active: ${active:-unknown} (rec: network-throughput)"
+  else
+    if [[ "$active" != "network-throughput" ]]; then
+      log_info "Setting tuned profile to network-throughput"
+      tuned-adm profile network-throughput || log_warn "Failed to set tuned profile"
+    fi
+  fi
+}
+
+apply_cpu_governor() {
+  if [[ ! -d /sys/devices/system/cpu/cpu0/cpufreq ]]; then
+    log_warn "Cannot set CPU governor: cpufreq not supported on this host"
+    return
+  fi
+  if command -v cpupower >/dev/null 2>&1; then
+    log_info "Setting CPU governor to 'performance' using cpupower"
+    cpupower frequency-set -g performance || log_warn "cpupower failed"
+  else
+    log_info "Setting CPU governors to 'performance' via sysfs"
+    for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+      echo performance >"$gov" 2>/dev/null || true
+    done
+  fi
+}
+
+check_cpu_governor() {
+  if [[ ! -d /sys/devices/system/cpu/cpu0/cpufreq ]]; then
+    log_warn "cpufreq not available or governor support missing; skipping governor check"
+    return
+  fi
+  if ! command -v cpupower >/dev/null 2>&1; then
+    MISSING_TOOLS+=("cpupower (dnf install kernel-tools)")
+  fi
+  local governors
+  governors=$(for cf in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do cat "$cf" 2>/dev/null || true; done | sort -u)
+  echo "CPU governors: $governors"
+  if [[ "$governors" != "performance" ]]; then
+    log_warn "Non 'performance' CPU governor detected: $governors (rec: performance)"
+  fi
+}
+
+check_iommu() {
+  # Check kernel cmdline for IOMMU options
+  local cmdline cpu_vendor iommu_cmd
+  cmdline=$(cat /proc/cmdline 2>/dev/null || true)
+  
+  # Detect CPU vendor (Intel vs AMD) per Fasterdata recommendations
+  if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="Intel"
+    iommu_cmd="intel_iommu=on iommu=pt"
+  elif grep -q '^vendor_id.*AuthenticAMD' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="AMD"
+    iommu_cmd="amd_iommu=on iommu=pt"
+  else
+    cpu_vendor="unknown"
+    iommu_cmd="iommu=pt (with intel_iommu=on or amd_iommu=on)"
+  fi
+  
+  if echo "$cmdline" | grep -q -E 'intel_iommu=on|amd_iommu=on|iommu=pt|iommu=on'; then
+    echo "IOMMU enabled via kernel command-line: $cmdline" | sed 's/^/  /'
+  else
+    log_warn "IOMMU not enabled in kernel command-line (CPU: $cpu_vendor, rec: $iommu_cmd for SR-IOV/perf tuning)"
+    echo "IOMMU setup: Edit GRUB configuration to enable IOMMU (per Fasterdata):"
+    echo "  1. Edit /etc/default/grub"
+    echo "  2. Add to GRUB_CMDLINE_LINUX: $iommu_cmd"
+    echo "  3. Example: GRUB_CMDLINE_LINUX=\"root=... $iommu_cmd ...\""
+    echo "  4. Regenerate GRUB: grub2-mkconfig -o /boot/grub2/grub.cfg"
+    echo "  5. Reboot the system for changes to take effect"
+    echo "  6. Verify with: cat /proc/cmdline (should show iommu=pt)"
+  fi
+}
+
+print_host_info() {
+  local os_release kernel_ver mem_info_str fqdn smt_status cpu_info cpu_vendor
+  os_release=$(awk -F'=' '/^PRETTY_NAME/ {print $2}' /etc/os-release 2>/dev/null | tr -d '"')
+  kernel_ver=$(uname -r)
+  fqdn=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "unknown")
+  local mem_total_kb
+  mem_total_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null)
+  if [[ -n "$mem_total_kb" ]]; then
+    local mem_gb=$((mem_total_kb / 1024 / 1024))
+    mem_info_str="${mem_gb} GiB"
+  else
+    mem_info_str="unknown"
+  fi
+  
+  # Get CPU info
+  local cpu_count cpu_model cpu_mhz
+  cpu_count=$(grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo "unknown")
+  if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="Intel"
+  elif grep -q '^vendor_id.*AuthenticAMD' /proc/cpuinfo 2>/dev/null; then
+    cpu_vendor="AMD"
+  else
+    cpu_vendor="unknown"
+  fi
+  cpu_model=$(awk -F':' '/^model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null | xargs)
+  # Extract CPU clock speed from /proc/cpuinfo (try cpu MHz first, fallback to max freq)
+  cpu_mhz=$(awk -F':' '/^cpu MHz/ {print int($2); exit}' /proc/cpuinfo 2>/dev/null)
+  if [[ -z "$cpu_mhz" ]] || [[ "$cpu_mhz" -eq 0 ]]; then
+    # Try /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq (in kHz)
+    local max_freq_khz
+    max_freq_khz=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq 2>/dev/null)
+    if [[ -n "$max_freq_khz" ]]; then
+      cpu_mhz=$((max_freq_khz / 1000))
+    fi
+  fi
+  local cpu_speed_str=""
+  if [[ -n "$cpu_mhz" ]] && [[ "$cpu_mhz" -gt 0 ]]; then
+    # Convert MHz to GHz using bash arithmetic
+    local cpu_ghz_int=$((cpu_mhz / 1000))
+    local cpu_ghz_frac=$(((cpu_mhz % 1000 + 50) / 100))  # Round to 1 decimal place
+    cpu_speed_str=" @ ${cpu_ghz_int}.${cpu_ghz_frac} GHz"
+  fi
+  if [[ -n "$cpu_model" ]]; then
+    cpu_info="$cpu_count cores, $cpu_vendor: $cpu_model$cpu_speed_str"
+  else
+    cpu_info="$cpu_count cores, $cpu_vendor$cpu_speed_str"
+  fi
+  
+  # Check SMT status
+  if [[ -r /sys/devices/system/cpu/smt/control ]]; then
+    smt_status=$(cat /sys/devices/system/cpu/smt/control)
+    if [[ "$smt_status" == "on" ]]; then
+      smt_status="$(colorize green "on")"
+    else
+      smt_status="$(colorize yellow "$smt_status")"
+    fi
+  else
+    smt_status="not available"
+  fi
+  
+  echo "Host Info:"
+  echo "  FQDN: $fqdn"
+  echo "  OS: ${os_release:-unknown}"
+  echo "  Kernel: $kernel_ver"
+  echo "  Memory: $mem_info_str"
+  echo "  CPUs: $cpu_info"
+  echo "  SMT: $smt_status"
+}
+
+check_smt() {
+  if [[ ! -r /sys/devices/system/cpu/smt/control ]]; then
+    log_detail "SMT control not available on this system"
+    return
+  fi
+  local smt_status
+  smt_status=$(cat /sys/devices/system/cpu/smt/control)
+  log_detail "SMT status: $smt_status"
+  
+  if [[ "$smt_status" != "on" ]]; then
+    log_warn "SMT is currently $smt_status (recommendation: on for measurement hosts; off for low-latency/isolated workloads)"
+    echo "SMT control: to enable, run: echo on | sudo tee /sys/devices/system/cpu/smt/control"
+    echo "SMT control: to disable, run: echo off | sudo tee /sys/devices/system/cpu/smt/control"
+  fi
+}
+
+driver_vendor_hint() {
+  case "$1" in
+    mlx5_core|mlx4_en|mlx4_core) echo "Mellanox/NVIDIA";;
+    bnxt_en|tg3|bnx2x|bnx2) echo "Broadcom";;
+    ixgbe|i40e|ice|e1000e|igb) echo "Intel";;
+    *) echo "Other";;
+  esac
+}
+
+check_drivers() {
+  if ! command -v ethtool >/dev/null 2>&1; then
+    log_warn "ethtool not installed; skipping driver version checks"
+    MISSING_TOOLS+=("ethtool (dnf install ethtool)")
+    return
+  fi
+
+  local -A vendor_hint_seen=()
+  local kernel_hint_added=0
+  echo "Driver info:"
+  for iface in $(get_ifaces); do
+    local info
+    info=$(ethtool -i "$iface" 2>/dev/null)
+    local drv version fw bus
+    drv=$(awk -F': ' '/driver:/ {print $2}' <<<"$info")
+    version=$(awk -F': ' '/version:/ {print $2}' <<<"$info")
+    fw=$(awk -F': ' '/firmware-version:/ {print $2}' <<<"$info")
+    bus=$(awk -F': ' '/bus-info:/ {print $2}' <<<"$info")
+    local vendor
+    vendor=$(driver_vendor_hint "$drv")
+    local modpath pkg pkgver
+    modpath=$(modinfo -n "$drv" 2>/dev/null || true)
+    pkg=$(rpm -q --whatprovides "$modpath" 2>/dev/null | head -n1 || true)
+
+    log_detail "Driver $iface: driver=$drv version=${version:-unknown} firmware=${fw:-unknown} vendor=${vendor:-unknown} pkg=${pkg:-unknown} bus=${bus:-unknown}"
+    echo "  $iface: driver=$drv version=${version:-unknown} firmware=${fw:-unknown} vendor=${vendor:-unknown} pkg=${pkg:-unknown}"
+
+    local kernel_hint=""
+    if [[ -n "$LATEST_KERNEL" && -n "$RUNNING_KERNEL" ]]; then
+      local latest_base="${LATEST_KERNEL%.x86_64}"
+      local running_base="${RUNNING_KERNEL%.x86_64}"
+      if [[ "$latest_base" != "$running_base" ]]; then
+        kernel_hint="Kernel update available: dnf update kernel && reboot (current: $RUNNING_KERNEL, latest: $LATEST_KERNEL)."
+      fi
+    fi
+
+    local vendor_hint=""
+    case "$vendor" in
+      "Mellanox/NVIDIA") vendor_hint="For ConnectX/mlx5, keep kernel+linux-firmware current or use NVIDIA OFED if required (see https://network.nvidia.com/products/ethernet-drivers/).";;
+      "Broadcom") vendor_hint="Broadcom NICs track the distro kernel; keep kernel+linux-firmware current and use vendor firmware tools (e.g., bnxtnvm) when available.";;
+      "Intel") vendor_hint="Intel NICs track the distro kernel; update kernel+linux-firmware for latest drivers/firmware blobs.";;
+      *) vendor_hint="Keep kernel+linux-firmware current for latest in-kernel drivers.";;
+    esac
+
+    if [[ -n "$kernel_hint" && $kernel_hint_added -eq 0 ]]; then
+      DRIVER_UPDATES+=("$kernel_hint")
+      kernel_hint_added=1
+    fi
+    if [[ -n "$vendor_hint" && -z "${vendor_hint_seen[$vendor]+x}" ]]; then
+      DRIVER_UPDATES+=("$vendor_hint")
+      vendor_hint_seen[$vendor]=1
+    fi
+  done
+}
+
+print_summary() {
+  printf "\nSummary:\n"
+  echo "- Target type: $TARGET_TYPE"
+  echo "- Sysctl mismatches: $SYSCTL_MISMATCHES"
+  if (( ${#IF_ISSUES[@]} > 0 )); then
+    echo "- Interfaces needing attention (${#IF_ISSUES[@]}):"
+    for item in "${IF_ISSUES[@]}"; do
+      echo "  * $item"
+    done
+  else
+    echo "- Interfaces needing attention: none"
+  fi
+
+  if (( ${#DRIVER_UPDATES[@]} > 0 )); then
+    local -A seen_drv=()
+    local unique_drv=()
+    for t in "${DRIVER_UPDATES[@]}"; do
+      if [[ -z "${seen_drv[$t]+x}" ]]; then
+        seen_drv[$t]=1
+        unique_drv+=("$t")
+      fi
+    done
+    echo "- Driver/version actions:"
+    for t in "${unique_drv[@]}"; do
+      echo "  * $t"
+    done
+  else
+    echo "- Driver/version actions: none"
+  fi
+
+  if (( ${#MISSING_TOOLS[@]} > 0 )); then
+    # de-duplicate
+    local -A seen=()
+    local unique=()
+    for t in "${MISSING_TOOLS[@]}"; do
+      if [[ -z "${seen[$t]+x}" ]]; then
+        seen[$t]=1
+        unique+=("$t")
+      fi
+    done
+    echo "- Install these tools for best results:"
+    for t in "${unique[@]}"; do
+      echo "  * $t"
+    done
+  else
+    echo "- Required tools: present"
+  fi
+
+  if [[ -n "$LOGFILE" ]]; then
+    echo "- Detailed log: $LOGFILE"
+  fi
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --mode) MODE="$2"; shift 2;;
+      --ifaces) IFACES="$2"; shift 2;;
+      --target) TARGET_TYPE="$2"; shift 2;;
+      --color) USE_COLOR=1; shift;;
+      -h|--help) usage; exit 0;;
+      *) echo "Unknown arg: $1" >&2; usage; exit 1;;
+    esac
+  done
+
+  if [[ "$TARGET_TYPE" != "measurement" && "$TARGET_TYPE" != "dtn" ]]; then
+    echo "ERROR: --target must be measurement or dtn" >&2
+    exit 1
+  fi
+
+  init_log
+  set_speed_scaled_recs
+  cache_kernel_versions
+
+  if [[ "$MODE" != "audit" && "$MODE" != "apply" ]]; then
+    echo "ERROR: --mode must be audit or apply" >&2; exit 1
+  fi
+  [[ "$MODE" == "apply" ]] && require_root
+
+  if [[ "$MODE" == "audit" ]]; then
+    print_host_info
+    print_sysctl_diff
+  else
+    if ! has_bbr; then
+      log_warn "bbr not available; will set cubic live but leave bbr in config"
+    fi
+    apply_sysctl
+    apply_cpu_governor
+  fi
+
+  ensure_tuned_profile
+
+  local ifs
+  ifs=$(get_ifaces)
+  for iface in $ifs; do
+    if [[ "$MODE" == "audit" ]]; then
+      iface_audit "$iface"
+    else
+      iface_apply "$iface"
+    fi
+  done
+
+  # Extra host checks
+  if [[ "$MODE" == "audit" ]]; then
+    check_cpu_governor
+    check_iommu
+    check_smt
+    check_drivers
+  fi
+
+  if [[ "$MODE" == "apply" ]]; then
+    create_ethtool_persist_service
+    log_info "Apply complete. Consider rebooting or rerunning audit to confirm settings."
+  else
+    log_info "Audit complete. Entries marked with '*' differ from recommended values."
+  fi
+
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add EL9-focused tuning guide aligned with ESnet Fasterdata (host/network/DTN pages)
- Provide audit/apply script () for sysctl, tuned profile, and per-NIC settings
- Link guide from docs index for discoverability

## Details
- Guide:  (sources: fasterdata host/network/DTN pages). Includes scope, when-to-use, cautions, verification checklist, and persistence notes.
- Script: 
Sysctl audit (current vs recommended)
Key                                 Current                             Recommended                        
-------------------------------------------------------------------------------------------------
net.ipv4.tcp_window_scaling         1                                   1                                   
net.core.wmem_max                   2147483647                          536870912                           *
net.core.rmem_max                   2147483647                          536870912                           *
net.ipv4.tcp_mtu_probing            1                                   1                                   
net.core.netdev_max_backlog         1000                                250000                              *
net.ipv4.tcp_timestamps             1                                   1                                   
net.core.wmem_default               212992                              134217728                           *
net.ipv4.tcp_rmem                   4096	131072	1073741824              4096 87380 536870912                *
net.ipv4.tcp_low_latency            0                                   0                                   
net.ipv4.tcp_sack                   1                                   1                                   
net.core.default_qdisc              fq                                  fq                                  
net.ipv4.tcp_congestion_control     cubic                               bbr                                 *
net.core.rmem_default               212992                              134217728                           *
net.ipv4.tcp_wmem                   4096	16384	1073741824               4096 65536 536870912                *
\nInterface: ens1f0np0
ens1f0np0        UP             192.41.230.60/23 2001:48a8:68f7:1:192:41:230:60/64 fe80::1519:c59d:22d2:a0cb/64 
  txqueuelen: 1000 (rec: >= 10000)
  Offloads (current):
    rx-checksumming: on
    tx-checksumming: on
  Rings:
    Ring parameters for ens1f0np0:
    Pre-set maximums:
    RX:			2047
    RX Mini:		n/a
    RX Jumbo:		8191
    TX:			2047
    TX push buff len:	n/a
    HDS thresh:		1023
    Current hardware settings:
    RX:			2047
    RX Mini:		n/a
    RX Jumbo:		8188
    TX:			2047
    RX Buf Len:		n/a
    CQE Size:		n/a
    TX Push:		off
    RX Push:		off
    TX push buff len:	n/a
    TCP data split:		on
    HDS thresh:		640
  - Modes:  (default) and 
  - Sysctl recommendations: buffer sizes, backlog, fq, MTU probing, BBR (fallback to cubic if unavailable)
  - Tuned profile: sets  when available
  - Per-NIC: txqueuelen >= 10000, RX/TX rings to driver max, GRO/GSO/TSO+checksums on, LRO off, qdisc fq
  - Writes  in apply mode; ethtool changes are live-only
- Index: added link under Host and Network Tuning.

## Testing
- Manual lint pass; script is bash -euo pipefail, no external runtime tests included.