### PR TITLE
docs: Add download & context to Fasterdata host tuning page

### DIFF
--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -94,6 +94,28 @@ Then it displays sysctl audit and per-NIC summaries, followed by a summary block
 
 Detailed log with full ethtool/sysctl/tc output is written to `/tmp/fasterdata-tuning-<UTC>.log` (configurable via `LOGFILE` env var).
 
+Getting the Fasterdata script
+-----------------------------
+You can download the script directly from the GitHub repo (raw) or the site after it is published:
+
+```
+https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+https://osg-htc.org/networking/perfsonar/tools_scripts/fasterdata-tuning.sh
+```
+
+Install quickly as follows:
+
+```bash
+sudo curl -L -o /usr/local/bin/fasterdata-tuning.sh https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+sudo chmod +x /usr/local/bin/fasterdata-tuning.sh
+```
+
+Then run an audit before applying changes:
+
+```bash
+bash /usr/local/bin/fasterdata-tuning.sh --mode audit --target measurement
+```
+
 #### Color Output
 
 Use `--color` flag to enable ANSI color codes:

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -49,6 +49,28 @@ Fasterdata host tuning script
 - Script: `fasterdata-tuning.sh` — audit/apply host & NIC tuning (ESnet Fasterdata-aligned) for EL9 systems
 - Path: `docs/perfsonar/tools_scripts/fasterdata-tuning.sh`
 
+Download
+--------
+You can download the raw script from the GitHub repo (master branch):
+
+```
+https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+```
+
+Or once the site is built, from the site URL:
+
+```
+https://osg-htc.org/networking/perfsonar/tools_scripts/fasterdata-tuning.sh
+```
+
+Quick install
+-------------
+```bash
+# Download and install in /usr/local/bin
+sudo curl -L -o /usr/local/bin/fasterdata-tuning.sh https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+sudo chmod +x /usr/local/bin/fasterdata-tuning.sh
+```
+
 Usage examples
 --------------
 


### PR DESCRIPTION
This PR improves the Fasterdata host tuning page and Tools & Scripts README by: - adding download links (raw GitHub and site path) and a quick install snippet, - adding Why use/Who should use/Verification steps and safety notes, - making the script easy to obtain for admins and test engineers. Please review and merge when satisfied; site build will be needed to publish content.