### PR TITLE
feat: --apply-iommu & --apply-smt flags + SHA verification; add --dry-run

### DIFF
--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -145,6 +145,22 @@ If a kernel update is available, the summary will recommend: `dnf update kernel 
 - Always validate after applying: check `podman ps`/services, run a quick throughput test, and review `dmesg`/`journal` for NIC or driver warnings.
 - To verify ethtool persistence service: `systemctl status ethtool-persist` and `systemctl cat ethtool-persist.service`
 
+Optional apply flags
+--------------------
+The script supports a few additional opt-in apply flags when run with `--mode apply`:
+
+- `--apply-iommu`: Edit GRUB to add recommended `iommu=pt` plus vendor-specific flags (Intel/AMD) and regenerate grub. Requires root and careful review before committing. Example:
+
+```
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-iommu --yes
+```
+
+- `--apply-smt on|off`: Apply SMT change at runtime. Use `--persist-smt` to make the choice persistent in GRUB. Example:
+
+```
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-smt off --persist-smt --yes
+```
+
 ## Manual checklist (summary of recommendations)
 
 Values shown below are baseline (1Gbps). The script scales them by fastest NIC speed and target type.

--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -159,6 +159,12 @@ sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply
 
 ```
 sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-smt off --persist-smt --yes
+
+Preview (dry-run) example:
+
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-iommu --dry-run
+```
 ```
 
 ## Manual checklist (summary of recommendations)

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -71,6 +71,22 @@ sudo curl -L -o /usr/local/bin/fasterdata-tuning.sh https://raw.githubuserconten
 sudo chmod +x /usr/local/bin/fasterdata-tuning.sh
 ```
 
+Verify checksum
+---------------
+You can verify the script integrity with the provided SHA256 file:
+
+```bash
+curl -L -o /tmp/fasterdata-tuning.sh.sha256 https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
+sha256sum -c /tmp/fasterdata-tuning.sh.sha256 --status && echo "OK" || echo "Checksum mismatch"
+```
+
+Optional flags (apply mode only)
+--------------------------------
+- `--apply-iommu`: Update GRUB `GRUB_CMDLINE_LINUX` to add vendor + `iommu=pt` and regenerate grub (requires `--mode apply` and root).
+- `--apply-smt on|off`: Change SMT state at runtime; use `--persist-smt` to also persist via GRUB edits.
+- `--persist-smt`: Persist SMT change by adding/removing `nosmt` in the kernel cmdline.
+- `--yes`: Non-interactive confirmation for apply flags.
+
 Usage examples
 --------------
 

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -86,6 +86,7 @@ Optional flags (apply mode only)
 - `--apply-smt on|off`: Change SMT state at runtime; use `--persist-smt` to also persist via GRUB edits.
 - `--persist-smt`: Persist SMT change by adding/removing `nosmt` in the kernel cmdline.
 - `--yes`: Non-interactive confirmation for apply flags.
+- `--dry-run`: Preview the changes that would be made (GRUB edits and sysfs writes) without applying them. Use for validation and audits.
 
 Usage examples
 --------------

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.md
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.md
@@ -21,6 +21,16 @@ sudo curl -L -o /usr/local/bin/fasterdata-tuning.sh https://osg-htc.org/networki
 sudo chmod +x /usr/local/bin/fasterdata-tuning.sh
 ```
 
+Verify the checksum
+-------------------
+To verify the script integrity, compare the downloaded script with the provided SHA256 checksum file in this repo:
+
+```bash
+curl -L -o /tmp/fasterdata-tuning.sh https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
+curl -L -o /tmp/fasterdata-tuning.sh.sha256 https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
+sha256sum -c /tmp/fasterdata-tuning.sh.sha256 --status && echo "OK" || echo "Checksum mismatch"
+```
+
 Why use this script?
 ---------------------
 This script packages ESnet Fasterdata best practices into an audit/apply helper that:
@@ -79,6 +89,13 @@ Notes
 - IOMMU: The script checks whether `iommu=pt` plus vendor-specific flags (`intel_iommu=on` or `amd_iommu=on`) are present. It only recommends GRUB edits (requires reboot) — it does not modify GRUB automatically unless you explicitly opt-in via a future apply flag.
 - SMT: The script detects SMT status and suggests commands to toggle runtime SMT; persistence requires GRUB edits (kernel cmdline). It does not toggle SMT by default.
 - Apply mode writes `/etc/sysctl.d/90-fasterdata.conf` and creates `/etc/systemd/system/ethtool-persist.service` when necessary.
+
+Optional apply flags (use with `--mode apply`):
+
+- `--apply-iommu`: Edit GRUB to add `iommu=pt` and vendor-specific flags (e.g., `intel_iommu=on iommu=pt`) to the kernel cmdline and regenerate grub. Requires confirmation or `--yes` to skip interactive prompt.
+- `--apply-smt on|off`: Toggle SMT state at runtime. Requires `--mode apply`. Example: `--apply-smt off`.
+- `--persist-smt`: If set along with `--apply-smt`, also persist the change via GRUB edits (`nosmt` applied/removed).
+- `--yes`: Skip interactive confirmations; use with caution.
 
 Reference and source
 --------------------

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.md
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.md
@@ -96,6 +96,12 @@ Optional apply flags (use with `--mode apply`):
 - `--apply-smt on|off`: Toggle SMT state at runtime. Requires `--mode apply`. Example: `--apply-smt off`.
 - `--persist-smt`: If set along with `--apply-smt`, also persist the change via GRUB edits (`nosmt` applied/removed).
 - `--yes`: Skip interactive confirmations; use with caution.
+- `--dry-run`: Preview the exact GRUB and sysfs commands that would be run without actually applying them. Useful for audits and CI checks.
+Example (preview only):
+
+```bash
+sudo bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-iommu --dry-run
+```
 
 Reference and source
 --------------------

--- a/docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
+++ b/docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
@@ -1,0 +1,2 @@
+6b9e3a85390fe37451cffe8410c0ecfa6b8ee2e9a8652f6af55f7e3b3d4736d4  fasterdata-tuning.sh
+6b9e3a85390fe37451cffe8410c0ecfa6b8ee2e9a8652f6af55f7e3b3d4736d4   fasterdata-tuning.sh

--- a/site/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
+++ b/site/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
@@ -1,0 +1,2 @@
+6b9e3a85390fe37451cffe8410c0ecfa6b8ee2e9a8652f6af55f7e3b3d4736d4  fasterdata-tuning.sh
+6b9e3a85390fe37451cffe8410c0ecfa6b8ee2e9a8652f6af55f7e3b3d4736d4   fasterdata-tuning.sh


### PR DESCRIPTION
This PR contains the following additions to `fasterdata-tuning.sh` and associated documentation:

Summary:
- Adds `--apply-iommu` and `--apply-smt` (plus `--persist-smt` and `--yes`) for safe, opt-in application of IOMMU and SMT settings on EL9 hosts.
- Adds `--dry-run` to preview GRUB, kernel, and sysfs changes without applying them (non-root friendly).
- Adds a `SHA256` checksum file for the script and verification instructions in documentation.
- Adds documentation (markdown) and a README update, installs the raw script in site assets for download.

Why:
- Improves operational security and ease of use for site operations and CI environments; admins can safely review what changes would be made before applying.

What changed technically:
- New flags: `--apply-iommu`, `--apply-smt on|off`, `--persist-smt`, `--dry-run`, `--yes`.
- Implemented `apply_iommu()` and `apply_smt()` functions with robust backup and guard rails.
- Dry-run previews commands that would modify `/etc/default/grub`, and sysfs writes (SMT).
- Added checksum file `docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256` and verification examples in docs.

Safety measures:
- All GRUB edits and sysfs writes require `--mode apply`.
- Interactive confirmation by default; supply `--yes` to skip.
- Backups of `/etc/default/grub` are created before editing; script will not progress if `grub2-mkconfig`/`update-grub` unavailable.
- `--dry-run` previews actions and does not require privileged execution.

How to test locally (non-destructive):
1) Run a normal audit and verify output:
   bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode audit --target measurement

2) Preview GRUB edits (no root):
   bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-iommu --dry-run --target measurement

3) Preview SMT change and GRUB persistence (no root):
   bash docs/perfsonar/tools_scripts/fasterdata-tuning.sh --mode apply --apply-smt off --persist-smt --dry-run --target measurement

4) Validate the SHA file:
   curl -L -o /tmp/fasterdata-tuning.sh https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh
   curl -L -o /tmp/fasterdata-tuning.sh.sha256 https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/fasterdata-tuning.sh.sha256
   sha256sum -c /tmp/fasterdata-tuning.sh.sha256 --status && echo OK || echo FAILED

ShellCheck notes:
- Static checks were run (shellcheck) and reported only non-critical warnings (SC2155, SC2120, SC2119). These are informational; the script remains executable and functionally correct, but I can address them before merging if desired.

Acceptance criteria / merge readiness:
- `--help` includes new flags and usage examples.
- Dry-run behavior is validated and does not modify the system.
- Documentation has been updated to show usage and verification steps, and the site will be rebuilt after merge to expose pages and assets.

