### PR TITLE
perfSONAR: ignore NICs without gateway in auto-detect configs

### DIFF
--- a/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
+++ b/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
@@ -451,6 +451,14 @@ generate_config_from_system() {
             continue
         fi
 
+        # If a NIC lacks both IPv4 and IPv6 gateways (i.e., management-only NIC without a gateway),
+        # ignore it by default (skip). Keep the device if it is the DEFAULT_ROUTE_NIC so the system
+        # default route device remains considered.
+        if [ "$dev" != "$DEFAULT_ROUTE_NIC" ] && [ "${gw4:-}" = "-" ] && [ "${gw6:-}" = "-" ]; then
+            log "Skipping device $dev: no IPv4/IPv6 gateway detected"
+            continue
+        fi
+
         NIC_NAMES+=("$dev")
         NIC_IPV4_ADDRS+=("$ipv4_addr")
         NIC_IPV4_PREFIXES+=("$ipv4_prefix")


### PR DESCRIPTION
Auto-generate PBR config should skip management-only NICs without gateways to avoid downstream scripts failing. This patch updates generate_config_from_system() in perfSONAR-pbr-nm.sh to skip NICs whose IPv4 and IPv6 gateway are both absent, unless the NIC is the current default route device. This prevents scripts that assume NICs have gateways from failing. Please review and let me know if you prefer this filter to be opt-in via CLI.

Files: docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh