### PR TITLE
docs: perfSONAR-pbr-nm: document skipping NICs without gateways (auto-gen)

### DIFF
--- a/docs/perfsonar/install-testpoint.md
+++ b/docs/perfsonar/install-testpoint.md
@@ -132,6 +132,8 @@ Recommended: use the helper script to generate and apply NetworkManager profiles
     /opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --generate-config-auto
     ```
 
+    Note: The auto-generator intentionally skips NICs that have neither an IPv4 nor an IPv6 gateway (e.g., management-only NICs) to avoid writing non-functional NetworkManager profiles. To include such a NIC in the configuration, set an explicit gateway or mark it as `DEFAULT_ROUTE_NIC` in `/etc/perfSONAR-multi-nic-config.conf`.
+
 Review and adjust /etc/perfSONAR-multi-nic-config.conf if needed.
 
 1. Dry run the apply step:

--- a/docs/perfsonar/tools_scripts/README.md
+++ b/docs/perfsonar/tools_scripts/README.md
@@ -269,7 +269,7 @@ bash perfSONAR-pbr-nm.sh --yes
 Gateway requirement, inference, and generator warnings
 -----------------------------------------------------
 
-- Any NIC with an IPv4 address must have a corresponding IPv4 gateway; likewise for IPv6.
+- Any NIC with an IPv4 address should have a corresponding IPv4 gateway; likewise for IPv6. If a NIC lacks a gateway, the generator will attempt conservative inference (below). If a device has no IPv4 or IPv6 gateway (e.g., a management-only NIC), the generator will intentionally skip that NIC when creating an _auto-generated_ config to avoid generating unusable NetworkManager profiles unless you explicitly set the device as `DEFAULT_ROUTE_NIC`.
 - Conservative gateway inference: if a NIC has an address/prefix but no gateway, the tool will try to reuse a gateway from another NIC on the SAME subnet.
     - IPv4: subnets are checked in bash; one unambiguous match is required.
     - IPv6: requires `python3` (`ipaddress` module) to verify the gateway is in the same prefix; link-local gateways (fe80::/10) are not reused; one unambiguous match is required.

--- a/docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh
+++ b/docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh
@@ -143,6 +143,7 @@ step_generate_config() {
   [ "$AUTO_YES" = true ] && gen_cmd+=(--yes)
   run "${gen_cmd[@]}"
   echo "Edit /etc/perfSONAR-multi-nic-config.conf if needed (gateways, DEFAULT_ROUTE_NIC)."
+  echo "Note: The auto-generator will skip NICs that have neither an IPv4 nor an IPv6 gateway (management-only NICs) unless they are set as DEFAULT_ROUTE_NIC."
   if [ "$NON_INTERACTIVE" != true ]; then
     ${EDITOR:-vi} /etc/perfSONAR-multi-nic-config.conf || true
   fi

--- a/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
+++ b/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
@@ -83,6 +83,12 @@ Options:
   --debug                     Run commands in debug mode (bash -x)
     --rebuild-all               Destructive full rebuild (remove all NM connections and rules first)
     --apply-inplace             Explicitly select in-place apply (non-destructive, default)
+  
+Note:
+    --generate-config-auto will skip NICs that do not have either an IPv4 or
+    IPv6 gateway (i.e., management-only NICs) to avoid creating non-functional
+    NM connection files unless they are explicitly set as DEFAULT_ROUTE_NIC
+    or provided with a gateway.
 EOF
 }
 
@@ -352,6 +358,12 @@ run_shellcheck() {
 #     (or prints a preview in debug/dry-run mode).
 #   - Side effect (export): sets DEFAULT_ROUTE_NIC in the current shell so
 #     the caller can inspect which interface was chosen.
+#
+# Note: The auto-generator will skip NICs that lack both an IPv4 and IPv6
+# gateway (for example, management-only NICs) to avoid generating
+# non-functional NetworkManager connection profiles. The device will be
+# preserved if it is explicitly marked as DEFAULT_ROUTE_NIC or if you set an
+# explicit gateway.
 generate_config_from_system() {
     log "Auto-detecting network interfaces to generate $CONFIG_FILE"
 

--- a/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
+++ b/docs/perfsonar/tools_scripts/perfSONAR-pbr-nm.sh
@@ -451,6 +451,14 @@ generate_config_from_system() {
             continue
         fi
 
+        # If a NIC lacks both IPv4 and IPv6 gateways (i.e., management-only NIC without a gateway),
+        # ignore it by default (skip). Keep the device if it is the DEFAULT_ROUTE_NIC so the system
+        # default route device remains considered.
+        if [ "$dev" != "$DEFAULT_ROUTE_NIC" ] && [ "${gw4:-}" = "-" ] && [ "${gw6:-}" = "-" ]; then
+            log "Skipping device $dev: no IPv4/IPv6 gateway detected"
+            continue
+        fi
+
         NIC_NAMES+=("$dev")
         NIC_IPV4_ADDRS+=("$ipv4_addr")
         NIC_IPV4_PREFIXES+=("$ipv4_prefix")

--- a/docs/release-notes/quick-deploy-1.4.0.md
+++ b/docs/release-notes/quick-deploy-1.4.0.md
@@ -32,6 +32,7 @@ The legacy dependency checking script is deprecated. Its responsibilities are re
 - Updated Quick Deploy Steps 1–3 to surface orchestrator early and remove `sudo` prefixes.
 - Improved documentation spacing and markdownlint compliance.
 - Introduced non-disruptive default mode for PBR script, reducing need for console access.
+ - Auto-gen: `perfSONAR-pbr-nm.sh` generator now skips NICs with no IPv4/IPv6 gateway (management-only NICs) to avoid producing non-functional NetworkManager profiles; `DEFAULT_ROUTE_NIC` is preserved (see PR #28).
 - Added dedicated deprecation tracking file `DEPRECATION.md`.
 - Updated CHANGELOG with new version entry and deprecation notice.
 


### PR DESCRIPTION
This PR updates the documentation and script usage to clarify that the perfSONAR-pbr-nm auto-generator will skip NICs that have neither an IPv4 nor an IPv6 gateway (management-only NICs) to avoid creating non-functional NM connection profiles. It also documents that DEFAULT_ROUTE_NIC is preserved and how to include a management-only NIC by adding a gateway or marking it as DEFAULT_ROUTE_NIC.\n\nRelated: PR #28 (code change to skip NICs without gateways).