### PR TITLE
ci(verify): autoupdate .sha for changed docs scripts in same-repo PRs

### DIFF
--- a/.github/workflows/verify-site-scripts.yml
+++ b/.github/workflows/verify-site-scripts.yml
@@ -35,6 +35,17 @@ jobs:
         echo "$CHANGED" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
+    - name: Autoupdate SHA files for changed docs (same-repo PRs only)
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+      run: |
+        if [ -n "${{ steps.changed.outputs.changed_files }}" ]; then
+          files=$(echo "${{ steps.changed.outputs.changed_files }}" | tr '\n' ' ')
+          echo "Autoupdate sha for: $files"
+          ./.github/scripts/autoupdate-scripts-sha.sh $files || true
+        else
+          echo "No changed script files found; skipping autoupdate"
+        fi
+
     - name: Run verification script (changed files only)
       if: always()
       run: |


### PR DESCRIPTION
When a pull request originates from this repository, the verify workflow will run ./.github/scripts/autoupdate-scripts-sha.sh to update .sha256 files for changed scripts under docs/perfsonar/tools_scripts. This ensures the "Verify docs -> site script sync" job does not fail because .sha files are out-of-date in the PR. The step only runs for same-repo PRs to avoid committing to forks.