### PR TITLE
fix: simplify homepage formatting for better rendering

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,42 +7,38 @@ OSG Networking Area
 
 Choose the path that matches your goal:
 
-<div class="grid cards" markdown>
+### :rocket: Deploy perfSONAR
 
-- :rocket: **Deploy perfSONAR**
+Quick, tested steps to deploy a perfSONAR testpoint for OSG/WLCG monitoring.
 
-    ---
+- **Time:** 30-60 minutes
+- **Skill level:** Systems administrator
 
-    Quick, tested steps to deploy a perfSONAR testpoint for OSG/WLCG monitoring.
+**→ [Quick Deploy Guide](personas/quick-deploy/landing.md)**
 
-    **Time:** 30-60 minutes  
-    **Skill level:** Systems administrator
+---
 
-    [:octicons-arrow-right-24: Quick Deploy Guide](personas/quick-deploy/landing.md)
+### :wrench: Troubleshoot Network Issues
 
-- :wrench: **Troubleshoot Network Issues**
+Triage checklist and playbooks for diagnosing network problems.
 
-    ---
+- **Time:** Variable
+- **Skill level:** Network operator/admin
 
-    Triage checklist and playbooks for diagnosing network problems.
+**→ [Troubleshooting Guide](personas/troubleshoot/landing.md)**
 
-    **Time:** Variable  
-    **Skill level:** Network operator/admin
+---
 
-    [:octicons-arrow-right-24: Troubleshooting Guide](personas/troubleshoot/landing.md)
+### :telescope: Understand the System
 
-- :telescope: **Understand the System**
+Architecture, data pipelines, and research documentation.
 
-    ---
+- **Time:** Reading/reference
+- **Skill level:** Developer/researcher
 
-    Architecture, data pipelines, and research documentation.
+**→ [Architecture & Research](personas/research/landing.md)**
 
-    **Time:** Reading/reference  
-    **Skill level:** Developer/researcher
-
-    [:octicons-arrow-right-24: Architecture & Research](personas/research/landing.md)
-
-</div>
+---
 
 ## About OSG/WLCG Network Monitoring
 
@@ -55,7 +51,7 @@ WLCG and OSG jointly operate a worldwide network of `perfSONAR` agents that prov
 - Integration with WLCG/OSG dashboards and alerting
 - Community-maintained test meshes
 
-[Learn more about perfSONAR in OSG/WLCG](perfsonar-in-osg.md){ .md-button }
+**[Learn more about perfSONAR in OSG/WLCG →](perfsonar-in-osg.md)**
 
 ## Network Services & Data
 


### PR DESCRIPTION
## Problem

After merging PR #42, the homepage at https://osg-htc.org/networking/ has rendering issues with the "Get Started" section. The Material theme grid cards and special syntax aren't rendering properly.

## Solution

This PR simplifies the homepage formatting to use standard markdown that renders correctly:

- ✅ Replace  with standard H3 headings
- ✅ Remove Material-specific icon syntax ()
- ✅ Remove  class syntax
- ✅ Use horizontal rules () for visual separation
- ✅ Keep all content, emojis, and links intact

## Changes

**Before:**
```html
<div class="grid cards" markdown>
- :rocket: **Deploy perfSONAR**
    [:octicons-arrow-right-24: Quick Deploy Guide](...)
</div>
```

**After:**
```markdown
### :rocket: Deploy perfSONAR

Quick, tested steps...

**→ [Quick Deploy Guide](...)**

---
```

## Result

The homepage will now render cleanly with:
- Clear emoji-prefixed section headings
- Bullet lists for metadata (time, skill level)
- Bold link with arrow for CTAs
- Horizontal rules for visual separation

All without requiring additional MkDocs extensions or custom CSS.

## Testing

Verified the markdown syntax is standard and compatible with the current MkDocs configuration.