### PR TITLE
feat: enable emoji support in markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,9 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   - search


### PR DESCRIPTION
## Problem

The homepage uses emoji shortcodes (, , ) in the "Get Started" section, but they don't render as emojis on the deployed site at https://osg-htc.org/networking/

## Solution

Add the `pymdownx.emoji` extension to `mkdocs.yml` with Material theme's Twemoji integration.

## Changes

```yaml
markdown_extensions:
  # ... existing extensions ...
  - pymdownx.emoji:
      emoji_index: cd /root/Git-Repositories/networking && git push -u origin fix/enable-emoji-supportpython/name:material.extensions.emoji.twemoji
      emoji_generator: cd /root/Git-Repositories/networking && git push -u origin fix/enable-emoji-supportpython/name:material.extensions.emoji.to_svg
```

This enables:
- ✅ Emoji shortcode rendering (e.g., `:rocket:` → 🚀)
- ✅ Consistent emoji appearance across all browsers
- ✅ SVG-based rendering for crisp display at any size
- ✅ Works with Material for MkDocs theme

## Result

After merging, the homepage will properly display:
- 🚀 **Deploy perfSONAR**
- 🔧 **Troubleshoot Network Issues**
- 🔭 **Understand the System**

## Documentation

- [PyMdown Extensions - Emoji](https://facelessuser.github.io/pymdown-extensions/extensions/emoji/)
- [Material for MkDocs - Icons & Emojis](https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/)