### PR TITLE
docs(quick-deploy): fix broken editing/indentation in install-perfsonar-testpoint.md

### DIFF
--- a/docs/personas/quick-deploy/install-perfsonar-testpoint.md
+++ b/docs/personas/quick-deploy/install-perfsonar-testpoint.md
@@ -27,16 +27,16 @@ extract/save/restore registration config that you may want to use.
 ??? info "Quick capture of existing lsregistration config (if you have a src)"
     
     Download a temp copy:   
-```bash
-curl -fsSL \
-  https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/perfSONAR-update-lsregistration.sh \
-  -o /tmp/update-lsreg.sh
-chmod 0755 /tmp/update-lsreg.sh
-```
+    ```bash
+    curl -fsSL \
+      https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/perfSONAR-update-lsregistration.sh \
+      -o /tmp/update-lsreg.sh
+    chmod 0755 /tmp/update-lsreg.sh
+    ```
     Use the downloaded tool to extract a restore script:
-```bash
-/tmp/update-lsreg.sh extract --output /root/restore-lsreg.sh
-```
+    ```bash
+    /tmp/update-lsreg.sh extract --output /root/restore-lsreg.sh
+    ```
     Note: Repository clone instructions are in Step 2.
     **Note:** All shell commands assume an interactive root shell.
     
@@ -48,18 +48,18 @@ chmod 0755 /tmp/update-lsreg.sh
 
 1. **Set the hostname and time sync:** Pick the NIC that will own the default route for the hostname.
 
-```bash
-hostnamectl set-hostname <testpoint-hostname>
-systemctl enable --now chronyd
-timedatectl set-timezone <Region/City>
-```
+    ```bash
+    hostnamectl set-hostname <testpoint-hostname>
+    systemctl enable --now chronyd
+    timedatectl set-timezone <Region/City>
+    ```
 
 1. **Disable unused services:**
 
-```bash
-systemctl disable --now firewalld NetworkManager-wait-online
-dnf remove -y rsyslog
-```
+    ```bash
+    systemctl disable --now firewalld NetworkManager-wait-online
+    dnf remove -y rsyslog
+    ```
 
     ??? info "Why disable unused services?"
         
@@ -72,16 +72,16 @@ dnf remove -y rsyslog
         
 1. **Update the system:**
 
-```bash
-dnf -y update
- ```
+    ```bash
+    dnf -y update
+     ```
 
 1. **Record NIC names:** Document interface mappings for later PBR configuration.
 
-```bash
-nmcli device status
-ip -br addr
-```
+    ```bash
+    nmcli device status
+    ip -br addr
+    ```
 
 ---
 
@@ -101,8 +101,6 @@ curl -fsSL \
     https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/perfSONAR-orchestrator.sh \
     -o /tmp/perfSONAR-orchestrator.sh
 chmod 0755 /tmp/perfSONAR-orchestrator.sh
-
-/tmp/perfSONAR-orchestrator.sh
 ```
 
 **Interactive mode** (pause at each step, confirm/skip/quit):
@@ -126,20 +124,14 @@ chmod 0755 /tmp/perfSONAR-orchestrator.sh
 **Flags:**
 
 - `--option {A|B}` — A = testpoint only; B = testpoint + Let's Encrypt
-
 - `--fqdn NAME` — primary FQDN for certificates (Option B)
-
 - `--email ADDRESS` — email for Let's Encrypt (Option B)
-
 - `--non-interactive` — skip pauses, auto-confirm
-
 - `--yes` — auto-confirm internal script prompts
-
 - `--dry-run` — preview steps without executing
-
 - `--auto-update` — install and enable a systemd timer that pulls container images daily and restarts containers only if updated (creates `/usr/local/bin/perfsonar-auto-update.sh`, a systemd service and timer)
 
-**If you choose this path, skip to Step 7** (the orchestrator completes Steps 2–6 for you).
+**If you choose this path, skip to [Step 7](#step-7-register-and-configure-with-wlcgosg)** (the orchestrator completes Steps 2–6 for you).
 
 ---
 
@@ -161,9 +153,7 @@ dnf -y install podman podman-docker podman-compose \
 
 ```
 
-This ensures all subsequent steps (PBR generation, DNS checks, firewall hardening, container deployment) have their
-
-dependencies available.
+This ensures all subsequent steps (PBR generation, DNS checks, firewall hardening, container deployment) have their dependencies available.
 
 #### Step 2.2 – Bootstrap Helper Scripts
 
@@ -173,7 +163,9 @@ Use the bootstrap script to install helper scripts under `/opt/perfsonar-tp/tool
 curl -fsSL \
     https://raw.githubusercontent.com/osg-htc/networking/master/docs/perfsonar/tools_scripts/install_tools_scripts.sh \
     -o /tmp/install_tools_scripts.sh
+
 chmod 0755 /tmp/install_tools_scripts.sh
+
 /tmp/install_tools_scripts.sh /opt/perfsonar-tp
 ```
 
@@ -181,12 +173,10 @@ chmod 0755 /tmp/install_tools_scripts.sh
 
 ```bash
 # Check that all helper scripts were downloaded
-
 ls -1 /opt/perfsonar-tp/tools_scripts/*.sh | wc -l
 # Should show 11 shell scripts
 
 # Verify key scripts are present and executable
-
 ls -l /opt/perfsonar-tp/tools_scripts/{perfSONAR-pbr-nm.sh,perfSONAR-install-nftables.sh,perfSONAR-orchestrator.sh}
 ```
 
@@ -196,105 +186,93 @@ ls -l /opt/perfsonar-tp/tools_scripts/{perfSONAR-pbr-nm.sh,perfSONAR-install-nft
 
 !!! note "Skip this step if you used the orchestrator (Path A)"
     
-    The orchestrator automates PBR configuration. If you ran it in Step 2, skip to [Step 4](#step-4-configure-nftables-
-    selinux-and-fail2ban).
+    The orchestrator automates PBR configuration. If you ran it in Step 2, skip to [Step 4](#step-4-configure-nftables-selinux-and-fail2ban).
     
-    The script `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh` automates NetworkManager profiles and routing rule
-    setup. It fills out and consumes the network configuration in `/etc/perfSONAR-multi-nic-config.conf`.
+The script `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh` automates NetworkManager profiles and routing rule
+setup. It fills out and consumes the network configuration in `/etc/perfSONAR-multi-nic-config.conf`.
     
-### Modes
+??? info "Modes of operation"
 
-By default the script now performs an **in-place apply** that adjusts routes, rules, and NetworkManager connection
-properties **without deleting existing connections or flushing all system routes**. This minimizes disruption and
-usually avoids the need for a reboot.
+    By default the script now performs an **in-place apply** that adjusts routes, rules, and NetworkManager connection
+    properties **without deleting existing connections or flushing all system routes**. This minimizes disruption and
+    usually avoids the need for a reboot.
 
-An optional destructive mode `--rebuild-all` performs the original full workflow: backup existing profiles, flush all
-routes and rules, remove every NetworkManager connection, then recreate connections from scratch. Use this only for
-initial deployments or when you must completely reset inconsistent legacy state.
+    An optional destructive mode `--rebuild-all` performs the original full workflow: backup existing profiles, flush all
+    routes and rules, remove every NetworkManager connection, then recreate connections from scratch. Use this only for
+    initial deployments or when you must completely reset inconsistent legacy state.
 
-| Mode | Flag | Disruption | When to use |
-|------|------|------------|-------------|
-| In-place (default) | (none) or `--apply-inplace` | Low (interfaces stay up; rules adjusted) | Routine updates, gateway changes, add routes |
-| Full rebuild | `--rebuild-all` | High (connections removed; brief connectivity drop) | First-time setup, severe misconfiguration |
+    | Mode | Flag | Disruption | When to use |
+    |------|------|------------|-------------|
+    | In-place (default) | (none) or `--apply-inplace` | Low (interfaces stay up; rules adjusted) | Routine updates, gateway changes, add routes |
+    | Full rebuild | `--rebuild-all` | High (connections removed; brief connectivity drop) | First-time setup, severe misconfiguration |
 
 ### Safety Enhancements
 
 - Detects active SSH session interface and avoids extra disruption to that NIC in in-place mode.
-
 - Prompts are still skipped with `--yes`.
-
 - Dry-run preview supported via `--dry-run` (combine with `--debug` for verbose output).
-
 - Reboot is **no longer generally required**; only consider one if NetworkManager fails to apply the new rules cleanly.
 
-1. **Generate config file automatically (or preview):**
+### Generate config file automatically (or preview)
 
-    !!! warning "Gateways required for addresses"
+!!! warning "Gateways required for addresses"
         
-        Any NIC with an IPv4 address must also have an IPv4 gateway, and any NIC with an IPv6 address must have an IPv6 gateway.
-        If the generator cannot detect a gateway, it adds a WARNING block to the generated file listing affected NICs. Edit
-        `NIC_IPV4_GWS`/`NIC_IPV6_GWS` accordingly before applying changes.
+    Any NIC with an IPv4 address must also have an IPv4 gateway, and any NIC with an IPv6 address must have an IPv6 gateway.
+    If the generator cannot detect a gateway, it adds a WARNING block to the generated file listing affected NICs. Edit
+    `NIC_IPV4_GWS`/`NIC_IPV6_GWS` accordingly before applying changes.
         
-    !!! note "Gateway prompts"
+??? note "Gateway prompts"
         
-        During generation, the script attempts to detect gateways per-NIC. If a NIC has an IP address but no gateway could be
-        determined, it will prompt you interactively to enter an IPv4 and/or IPv6 gateway (or `-` to skip). Prompts are skipped
-        in non-interactive sessions or when you use `--yes`.
+    During generation, the script attempts to detect gateways per-NIC. If a NIC has an IP address but no gateway could be
+    determined, it will prompt you interactively to enter an IPv4 and/or IPv6 gateway (or `-` to skip). Prompts are skipped
+    in non-interactive sessions or when you use `--yes`. Note, NICs without gateways are assumed to NOT be used for perfSONAR.
         
-    Preview generation (no changes):
+Preview generation (**no changes**):
         
 ```bash
-/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --generate-config-debug
-    
- ```
-
-    Generate and write the config file:
-        
-```bash
-/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --generate-config-auto
-    
+/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --generate-config-debug    
 ```
 
-    The script writes the config file to `/etc/perfSONAR-multi-nic-config.conf`. Edit to adjust site-specific values (e.g.,
-    confirm `DEFAULT_ROUTE_NIC`, add `NIC_IPV4_ADDROUTE` entries) and verify the entries.  Next step is to apply the network
-    changes...
+Generate and **write** the config file:
         
-1. **Apply changes (in-place default):**
+```bash
+/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --generate-config-auto 
+```
 
-    !!! warning "Connect via console for network changes"
+The script writes the config file to `/etc/perfSONAR-multi-nic-config.conf`. Edit to adjust site-specific values (e.g.,
+confirm `DEFAULT_ROUTE_NIC`, add `NIC_IPV4_ADDROUTE` entries) and verify the entries.  Next step is to apply the network
+changes...
         
-        When applying network changes across an ssh connection, your session may be interrupted.   Please try to run the
+### Apply changes (in-place default)
+
+!!! warning "Connect via console for network changes"
         
-        perfSONAR-pbr-nm.sh script when connected either directly to the console or by using 'nohup' in front of the script
-        invocation.
-        
-    ??? If SSH connection drops during network reconfiguration:
-        
-        1. Access via BMC/iLO/iDRAC console or physical console
+    When applying network changes across an ssh connection, your session may be interrupted.   Please try to run the
+    perfSONAR-pbr-nm.sh script when connected either directly to the console or by using 'nohup' in front of the script
+    invocation.
 
-        1. Review `/var/log/perfSONAR-multi-nic-config.log` for errors
-
-        1. Check network state with `nmcli connection show` and `ip addr`
-
-        1. Restore from backup if needed: backups are in `/var/backups/nm-connections-<timestamp>/`
-
-        1. Reapply config after corrections: `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --yes`
-
-    **In-place apply (recommended):**
+#### In-place apply (recommended)
 
 ```bash
 /opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --yes
-
 ```
+        
+??? info "If SSH connection drops during network reconfiguration:"
+        
+    1. Access via BMC/iLO/iDRAC console or physical console
+    1. Review `/var/log/perfSONAR-multi-nic-config.log` for errors
+    1. Check network state with `nmcli connection show` and `ip addr`
+    1. Restore from backup if needed: backups are in `/var/backups/nm-connections-<timestamp>/`
+    1. Reapply config after corrections: `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --yes`
 
-    **Full rebuild (destructive – removes all NM connections first):**
+
+#### Full rebuild (destructive – removes all NM connections first)
 
 ```bash
 /opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --rebuild-all --yes
-
 ```
 
-The script logs to `/var/log/perfSONAR-multi-nic-config.log`. After an in-place apply, a reboot is typically
+The policy based routing script logs to `/var/log/perfSONAR-multi-nic-config.log`. After an in-place apply, a reboot is typically
 unnecessary. If connectivity or rules appear inconsistent (`ip rule show` / `ip route` mismatch), consider a manual
 NetworkManager restart:
 
@@ -303,40 +281,33 @@ systemctl restart NetworkManager
 
 ```
 
-1. **DNS: forward and reverse entries (required):**
+### DNS: forward and reverse entries (required)
 
 All IP addresses that will be used for perfSONAR testing MUST have DNS entries: a forward (A/AAAA) record and a matching
 reverse (PTR) record. This is required so remote test tools and site operators can reliably reach and identify your
 host, and because some measurement infrastructure and registration systems perform forward/reverse consistency checks.
 
 - For single-stack IPv4-only hosts: ensure A and PTR are present and consistent.
-
 - For single-stack IPv6-only hosts: ensure AAAA and PTR are present and consistent.
-
 - For dual-stack hosts: both IPv4 and IPv6 addresses used for testing must have matching forward and reverse records (A+PTR and AAAA+PTR).
 
-??? example "Run the DNS checker" Validate forward/reverse DNS for addresses in `/etc/perfSONAR-multi-nic-config.conf`.
+??? info "Run the DNS checker" 
     
-    You can run a script to check DNS:
-```bash
-/opt/perfsonar-tp/tools_scripts/check-perfsonar-dns.sh
-    
-```
-    
-**Notes and automation tips:**
+    To validate forward/reverse DNS for addresses in `/etc/perfSONAR-multi-nic-config.conf` you can run a script:
+    ```bash
+    /opt/perfsonar-tp/tools_scripts/check-perfsonar-dns.sh
+    ```
+    **Notes and automation tips:**
     
     - The script above uses `dig` (bind-utils package) which is commonly available; you can adapt it
       to use `host` if preferred.
-
     - Run the check as part of your provisioning CI or as a pre-flight check before enabling measurement registration.
-
     - For large sites or many addresses, parallelize the checks (xargs -P) or use a small Python
       script that leverages `dns.resolver` for async checks.
-
     - If your PTR returns a hostname with a trailing dot, the script strips it before the forward check.
 
-If any addresses fail these checks, correct the DNS zone (forward and/or reverse) and allow DNS propagation before
-proceeding with registration and testing.
+    If any addresses fail these checks, correct the DNS zone (forward and/or reverse) and allow DNS propagation before
+    proceeding with registration and testing.
 
 **Verify the routing policy:**
 
@@ -356,8 +327,7 @@ route.
 
 !!! note "Skip this step if you used the orchestrator (Path A)"
     
-    The orchestrator automates security hardening. If you ran it in Step 2, skip to [Step 5](#step-5-deploy-the-
-    containerized-perfsonar-testpoint).
+    The orchestrator automates security hardening. If you ran it in Step 2, skip to [Step 5](#step-5-deploy-the-containerized-perfsonar-testpoint).
     
 Use `/opt/perfsonar-tp/tools_scripts/perfSONAR-install-nftables.sh` to configure a hardened nftables profile with
 optional SELinux and Fail2Ban support. No staging or copy step is required.
@@ -372,13 +342,13 @@ Prerequisites (not installed by the script and should have been installed when c
 
 If any prerequisite is missing, the script skips that component and continues.
 
-1. **Install/configure the desired options:**
+### Install/configure the desired options
 
+You can use the install script to install the options you want (selinux, fail2ban)
 ```bash
 /opt/perfsonar-tp/tools_scripts/perfSONAR-install-nftables.sh --selinux --fail2ban --yes
-
 ```
-
+ 
     - Use `--yes` to skip the interactive confirmation prompt (omit it if you prefer to review the
       summary and answer manually).
 
@@ -387,73 +357,67 @@ If any prerequisite is missing, the script skips that component and continues.
 The script writes nftables rules for perfSONAR services, derives SSH allow-lists from `/etc/perfSONAR-multi-nic-
 config.conf`, optionally adjusts SELinux, and enables Fail2ban jails—only if those components are already installed.
 
-    ??? info "SSH allow-lists and validation"
+??? info "SSH allow-lists and validation"
         
-        - Derives SSH allow-lists from `/etc/perfSONAR-multi-nic-config.conf` (CIDR prefixes and addresses).
+    - Derives SSH allow-lists from `/etc/perfSONAR-multi-nic-config.conf` (CIDR prefixes and addresses).
+    - Validates nftables rules before writing.
+    - Outputs: rules to `/etc/nftables.d/perfsonar.nft`, log to `/var/log/perfSONAR-install-nftables.log`, backups to `/var/backups/`.
 
-        - Validates nftables rules before writing.
-
-        - Outputs: rules to `/etc/nftables.d/perfsonar.nft`, log to `/var/log/perfSONAR-install-nftables.log`, backups to `/var/backups/`.
-
-    ??? tip "Preview nftables rules before applying"
+??? tip "Preview nftables rules before applying"
     
-        You can preview the fully rendered nftables rules (no changes are made):
+    You can preview the fully rendered nftables rules (no changes are made):
     
-```bash
-/opt/perfsonar-tp/tools_scripts/perfSONAR-install-nftables.sh --print-rules
+    ```bash
+    /opt/perfsonar-tp/tools_scripts/perfSONAR-install-nftables.sh --print-rules
+    ```
     
-```
-    
-    ??? tip "Manually add extra management hosts/subnets"
+??? tip "Manually add extra management hosts/subnets"
         
-        If you need to allow additional SSH sources not represented by your NIC-derived prefixes, edit
-        `/etc/nftables.d/perfsonar.nft` and add entries to the appropriate sets. Example:
+    If you need to allow additional SSH sources not represented by your NIC-derived prefixes, edit
+    `/etc/nftables.d/perfsonar.nft` and add entries to the appropriate sets. Example:
         
-```nft
-set ssh_access_ip4_subnets {
-    type ipv4_addr
-    flags interval
-    elements = { 192.0.2.0/24, 198.51.100.0/25 }
-}
+    ```nft
+    set ssh_access_ip4_subnets {
+        type ipv4_addr
+        flags interval
+        elements = { 192.0.2.0/24, 198.51.100.0/25 }
+    }
 
-set ssh_access_ip4_hosts {
-    type ipv4_addr
-    elements = { 203.0.113.10, 203.0.113.11 }
-}
+    set ssh_access_ip4_hosts {
+        type ipv4_addr
+        elements = { 203.0.113.10, 203.0.113.11 }
+    }
 
-set ssh_access_ip6_subnets {
-    type ipv6_addr
-    flags interval
-    elements = { 2001:db8:1::/64 }
-}
+    set ssh_access_ip6_subnets {
+        type ipv6_addr
+        flags interval
+        elements = { 2001:db8:1::/64 }
+    }
 
-set ssh_access_ip6_hosts {
-    type ipv6_addr
-    elements = { 2001:db8::10 }
-}
-
-```
+    set ssh_access_ip6_hosts {
+        type ipv6_addr
+        elements = { 2001:db8::10 }
+    }
+    ```
         
-        Then validate and reload (root shell):
+    Then validate and reload (root shell):
         
-```bash
-nft -c -f /etc/nftables.d/perfsonar.nft
-systemctl reload nftables || systemctl restart nftables
+    ```bash
+    nft -c -f /etc/nftables.d/perfsonar.nft
+    systemctl reload nftables || systemctl restart nftables
+    ```
+        
+### Confirm nftables state and security services
 
-```
+??? info "Verification commands"
         
-1. **Confirm nftables state and security services:**
-
-    ??? info "Verification commands"
+    ```bash
+    nft list ruleset
+    sestatus
+    systemctl status fail2ban
+    ```
         
-        ```bash
-        nft list ruleset
-        sestatus
-        systemctl status fail2ban
-
-        ```
-        
-    You may want to document any site-specific exceptions (e.g., additional allowed management hosts) in your change log.
+You may want to document any site-specific exceptions (e.g., additional allowed management hosts) in your change log.
         
 ---
 
@@ -461,15 +425,13 @@ systemctl reload nftables || systemctl restart nftables
 
 !!! note "Skip this step if you used the orchestrator (Path A)"
     
-    The orchestrator automates container deployment and certificate issuance. If you ran it in Step 2, skip to [Step
+    The orchestrator automates container deployment and certificate issuance. If you ran it in Step 2, skip to [Step 6](#step-6-configure-and-enroll-in-psconfig).
     
-    6](#step-6-configure-and-enroll-in-psconfig).
-    
-    Run the official testpoint image using Podman (or Docker). Choose one of the two deployment modes:
-    
-- Option A: Testpoint only (simplest) — only bind-mount `/opt/perfsonar-tp/psconfig` for pSConfig.
+Run the official testpoint image using Podman (or Docker). Choose one of the two deployment modes:
 
-- Option B: Testpoint + Let’s Encrypt — two containers that share Apache files and certs via host bind mounts.
+- **Option A:** Testpoint only (simplest) — only bind-mount `/opt/perfsonar-tp/psconfig` for pSConfig.
+
+- **Option B:** Testpoint + Let’s Encrypt — two containers that share Apache files and certs via host bind mounts.
 
 Use `podman-compose` (or `docker-compose`) in the examples below.
 
@@ -506,8 +468,7 @@ podman ps
 
 The container should show `healthy` status. The healthcheck monitors Apache HTTPS availability.
 
-That's it for the testpoint-only mode. Manage pSConfig files under `/opt/perfsonar-tp/psconfig` on the host; they are
-consumed by the container at `/etc/perfsonar/psconfig`. Jump to Step 6 below.
+Manage pSConfig files under `/opt/perfsonar-tp/psconfig` on the host; they are consumed by the container at `/etc/perfsonar/psconfig`. 
 
 #### Ensure containers restart automatically on reboot (systemd unit for testpoint - REQUIRED)
 
@@ -528,29 +489,24 @@ curl -fsSL \
 chmod 0755 /tmp/install-systemd-units.sh
 
 # Install testpoint-only systemd unit
-
 /tmp/install-systemd-units.sh --install-dir /opt/perfsonar-tp
 
 # Enable and start now
-
 systemctl enable --now perfsonar-testpoint.service
 
-
 # Verify service and containers
-
 systemctl status perfsonar-testpoint.service --no-pager
 podman ps
 ```
 
-Notes:
+??? info "Notes on podman/systemd"
 
-- The service uses `podman run --systemd=always` to enable proper systemd operation inside the container
+    - The service uses `podman run --systemd=always` to enable proper systemd operation inside the container
+    - The compose file is kept for reference but not used by the systemd units
+    - If you need to update container configuration, edit the systemd unit file directly: `/etc/systemd/system/perfsonar-testpoint.service`
+    - After editing the unit file, reload and restart: `systemctl daemon-reload && systemctl restart perfsonar-testpoint.service`
 
-- The compose file is kept for reference but not used by the systemd units
-
-- If you need to update container configuration, edit the systemd unit file directly: `/etc/systemd/system/perfsonar-testpoint.service`
-
-- After editing the unit file, reload and restart: `systemctl daemon-reload && systemctl restart perfsonar-testpoint.service`
+Jump to [Step 6](#step-6-configure-and-enroll-in-psconfig) below.
 
 ---
 
@@ -592,54 +548,40 @@ Run the bundled seeding helper script (automatically installed in Step 2):
 /opt/perfsonar-tp/tools_scripts/seed_testpoint_host_dirs.sh
 ```
 
-This script:
+??? info "Seed script details"
 
-- Pulls the latest perfSONAR testpoint image
-
-- Creates temporary containers to extract baseline files
-
-- Copies content to host directories
-
-- Verifies seeding was successful
-
-- Skips seeding if directories already have content (idempotent)
+    - Pulls the latest perfSONAR testpoint image
+    - Creates temporary containers to extract baseline files
+    - Copies content to host directories
+    - Verifies seeding was successful
+    - Skips seeding if directories already have content (idempotent)
 
 Verify seeding succeeded:
 
 ```bash
 # Should show config files
-
 ls -la /opt/perfsonar-tp/psconfig
 
-
 # Should show index.html and perfsonar/ directory
-
 ls -la /var/www/html
 
 # Should show sites-available/, sites-enabled/, etc.
-
 ls -la /etc/apache2
 ```
 
 ??? tip "SELinux labeling handled automatically"
     
     If SELinux is enforcing, the `:Z` and `:z` options in the compose files will cause Podman to relabel the host paths when
-    
     containers start. No manual `chcon` commands are required.
     
     **SELinux Volume Labels:**
     
-- `:Z` (uppercase) - Exclusive access. Podman creates a unique SELinux label for this volume that only this specific container can access. Use for volumes that should not be shared between containers.
-
-- `:z` (lowercase) - Shared access. Podman uses a shared SELinux label that multiple containers can access. Use for volumes that need to be accessed by multiple containers.
-
+    - `:Z` (uppercase) - Exclusive access. Podman creates a unique SELinux label for this volume that only this specific container can access. Use for volumes that should not be shared between containers.
+    - `:z` (lowercase) - Shared access. Podman uses a shared SELinux label that multiple containers can access. Use for volumes that need to be accessed by multiple containers.
     In our compose files:
-
-- `/etc/letsencrypt:/etc/letsencrypt:Z` - Exclusive to testpoint container
-
-- `/var/www/html:/var/www/html:z` - Shared between testpoint and certbot containers
-
-- `/etc/apache2:/etc/apache2:Z` - Exclusive to testpoint container
+    - `/etc/letsencrypt:/etc/letsencrypt:Z` - Exclusive to testpoint container
+    - `/var/www/html:/var/www/html:z` - Shared between testpoint and certbot containers
+    - `/etc/apache2:/etc/apache2:Z` - Exclusive to testpoint container
 
 #### 2) Deploy the testpoint with automatic SSL patching (recommended)
 
@@ -668,19 +610,17 @@ curl -fsSL \
     -o /opt/perfsonar-tp/docker-compose.yml
 ```
 
-**Note:** The `SERVER_FQDN` environment variable is **optional**. The entrypoint wrapper will auto-discover certificates
+??? note "The SERVER_FQDN use is optional"
 
-in `/etc/letsencrypt/live` and use the first one found. Only set `SERVER_FQDN` if you have multiple certificates and
-need to specify which one to use.
+    **Note:** The `SERVER_FQDN` environment variable is **optional**. The entrypoint wrapper will auto-discover certificates in `/etc/letsencrypt/live` 
+    and use the first one found. Only set `SERVER_FQDN` if you have multiple certificates and need to specify which one to use.
 
-If you want to explicitly set the FQDN (optional):
+    If you want to explicitly set the FQDN (optional):
 
-```bash
-
-# Optional: only needed if you have multiple certificates
-
-sed -i 's/# - SERVER_FQDN=.*/- SERVER_FQDN=<YOUR_FQDN>/' /opt/perfsonar-tp/docker-compose.yml
-```
+    ```bash
+    # Optional: only needed if you have multiple certificates
+    sed -i 's/# - SERVER_FQDN=.*/- SERVER_FQDN=<YOUR_FQDN>/' /opt/perfsonar-tp/docker-compose.yml
+    ```
 
 Start the containers:
 
@@ -711,16 +651,12 @@ curl -fsSL \
 chmod 0755 /tmp/install-systemd-units.sh
 
 # Install both testpoint and certbot systemd units
-
 /tmp/install-systemd-units.sh --install-dir /opt/perfsonar-tp --with-certbot
 
 # Enable and start services
-
 systemctl enable --now perfsonar-testpoint.service perfsonar-certbot.service
 
 # Verify services
-
-
 systemctl status perfsonar-testpoint.service perfsonar-certbot.service --no-pager
 podman ps
 ```
@@ -753,34 +689,24 @@ podman run --rm --net=host \
     
     **Podman options:**
     
-- `--rm` - Remove container after it exits
-
-- `--net=host` - Use host network (allows binding port 80)
-
-- `-v /etc/letsencrypt:/etc/letsencrypt:Z` - Mount certificate storage with exclusive SELinux label
-
-- `-v /var/www/html:/var/www/html:Z` - Mount webroot for HTTP-01 challenge
+    - `--rm` - Remove container after it exits
+    - `--net=host` - Use host network (allows binding port 80)
+    - `-v /etc/letsencrypt:/etc/letsencrypt:Z` - Mount certificate storage with exclusive SELinux label
+    - `-v /var/www/html:/var/www/html:Z` - Mount webroot for HTTP-01 challenge
 
     **Certbot options:**
 
-- `certonly` - Obtain certificate only, don't install it
-
-- `--standalone` - Run standalone HTTP server on port 80 for ACME HTTP-01 challenge
-
-- `--agree-tos` - Agree to Let's Encrypt Terms of Service
-
-- `--non-interactive` - Don't prompt for input (required for automation)
-
-- `-d <FQDN>` - Domain name(s) for the certificate (repeat for each domain/SAN)
-
-- `-m <EMAIL>` - Email for renewal notifications and account recovery
+    - `certonly` - Obtain certificate only, don't install it
+    - `--standalone` - Run standalone HTTP server on port 80 for ACME HTTP-01 challenge
+    - `--agree-tos` - Agree to Let's Encrypt Terms of Service
+    - `--non-interactive` - Don't prompt for input (required for automation)
+    - `-d <FQDN>` - Domain name(s) for the certificate (repeat for each domain/SAN)
+    - `-m <EMAIL>` - Email for renewal notifications and account recovery
 
 Replace:
 
 - `<SERVER_FQDN>` with your primary hostname (e.g., `psum05.aglt2.org`)
-
 - `<ALT_FQDN>` with additional FQDNs if needed (one `-d` flag per FQDN)
-
 - `<LETSENCRYPT_EMAIL>` with your email for certificate notifications
 
 After successful issuance, restart the perfsonar-testpoint container to trigger the automatic patching:
@@ -839,20 +765,14 @@ podman logs certbot 2>&1 | grep -A5 "deploy hook"
     If you prefer not to use the automatic patching entrypoint wrapper, you can use the standard compose file and manually
     patch the Apache SSL configuration after obtaining certificates.
     
-1. Use `docker-compose.testpoint-le.yml` instead of `docker-compose.testpoint-le-auto.yml`
-
-1. After obtaining Let's Encrypt certificates, run:
-
+    1. Use `docker-compose.testpoint-le.yml` instead of `docker-compose.testpoint-le-auto.yml`
+    1. After obtaining Let's Encrypt certificates, run:
     ```bash
     /opt/perfsonar-tp/tools_scripts/patch_apache_ssl_for_letsencrypt.sh <SERVER_FQDN>
-
     ```
-
-1. Reload Apache in the running container:
-
+    1. Reload Apache in the running container:
     ```bash
     podman exec perfsonar-testpoint apachectl -k graceful
-
     ```
 
 This approach requires manual intervention after initial certificate issuance and any time the container is recreated.
@@ -896,19 +816,15 @@ The automatic approach (using the entrypoint wrapper) eliminates this manual ste
 
 !!! note "Skip this step if you used the orchestrator (Path A)"
     
-    The orchestrator automates pSConfig enrollment. If you ran it in Step 2, skip to [Step 7](#step-7-register-and-
-    configure-with-wlcgosg).
+    The orchestrator automates pSConfig enrollment. If you ran it in Step 2, skip to [Step 7](#step-7-register-and-configure-with-wlcgosg).
     
-    We need to enroll your testpoint with the OSG/WLCG pSConfig service so tests are auto-configured. Use the "auto URL" for
+We need to enroll your testpoint with the OSG/WLCG pSConfig service so tests are auto-configured. Use the "auto URL" for each FQDN you expose for 
+perfSONAR (one or two depending on whether you split latency/throughput by hostname).
     
-    each FQDN you expose for perfSONAR (one or two depending on whether you split latency/throughput by hostname).
-    
-    Basic enroll (interactive root on the host; runs inside the container) if you have only one entry to make (automation
-    alternative below):
+Basic enroll (interactive root on the host; runs inside the container) if you have only one entry to make (automation alternative below):
     
 ```bash
 # Add auto URLs (configures archives too) and show configured remotes
-
 podman exec -it perfsonar-testpoint psconfig remote --configure-archives add \
     "https://psconfig.opensciencegrid.org/pub/auto/ps-lat-example.my.edu"
 
@@ -926,29 +842,23 @@ applying.
 
 ```bash
 # Dry run only (show planned URLs):
-
 /opt/perfsonar-tp/tools_scripts/perfSONAR-auto-enroll-psconfig.sh -n
 
 # Typical usage (podman):
-
 /opt/perfsonar-tp/tools_scripts/perfSONAR-auto-enroll-psconfig.sh -v
 
 podman exec -it perfsonar-testpoint psconfig remote list
 ```
 
-??? note "The auto enroll script details"
+??? note "The auto enroll psconfig script details"
     
-- Parses IP lists from `/etc/perfSONAR-multi-nic-config.conf`  (`NIC_IPV4_ADDRS` / `NIC_IPV6_ADDRS`).
+    - Parses IP lists from `/etc/perfSONAR-multi-nic-config.conf`  (`NIC_IPV4_ADDRS` / `NIC_IPV6_ADDRS`).
+    - Performs reverse DNS lookups (getent/dig) to derive FQDNs.
+    - Deduplicates while preserving discovery order.
+    - Adds each `https://psconfig.opensciencegrid.org/pub/auto/<FQDN>` with `--configure-archives`.
+    - Lists configured remotes and returns non-zero if any enrollment fails.
 
-- Performs reverse DNS lookups (getent/dig) to derive FQDNs.
-
-- Deduplicates while preserving discovery order.
-
-- Adds each `https://psconfig.opensciencegrid.org/pub/auto/<FQDN>` with `--configure-archives`.
-
-- Lists configured remotes and returns non-zero if any enrollment fails.
-
-Integrate into provisioning CI by running with `-n` (dry-run) for approval and then `-y` once approved.
+    Integrate into provisioning CI by running with `-n` (dry-run) for approval and then `-y` once approved.
 
 ---
 
@@ -958,42 +868,36 @@ Integrate into provisioning CI by running with `-n` (dry-run) for approval and t
 
     ??? info "Registration steps and portals"
         
-- Register the host in [OSG topology](https://topology.opensciencegrid.org/host).
-
-- Create or update a [GGUS](https://ggus.eu/) ticket announcing the new measurement point.
-
-- In [GOCDB](https://goc.egi.eu/portal/), add the service endpoint
+        - Register the host in [OSG topology](https://topology.opensciencegrid.org/host).
+        - Create or update a [GGUS](https://ggus.eu/) ticket announcing the new measurement point.
+        - In [GOCDB](https://goc.egi.eu/portal/), add the service endpoint
                 `org.opensciencegrid.crc.perfsonar-testpoint` bound to this host.
 
-1. **Document memberships:** update your site wiki or change log with assigned mesh names, feed  URLs, and support contacts.
+1. **Document memberships:**
 
-1. **Update Lookup Service registration inside the container**
+    Update your site wiki or change log with assigned mesh names, feed  URLs, and support contacts.
 
-Use the helper script to edit `/etc/perfsonar/lsregistrationdaemon.conf` inside the running `perfsonar-testpoint`
-container and restart the daemon only if needed.
+1. **Update Lookup Service registration inside the container:**
 
-Install and run examples below, pick which type you want (root shell):
+    Use the helper script to edit `/etc/perfsonar/lsregistrationdaemon.conf` inside the running `perfsonar-testpoint`
+    container and restart the daemon only if needed. Install and run examples below, pick which type you want (root shell):
 
-```bash
-# Preview changes only (uses the copy from /opt/perfsonar-tp/tools_scripts)
-/opt/perfsonar-tp/tools_scripts/perfSONAR-update-lsregistration.sh update \
-    --dry-run --site-name "Acme Co." --project WLCG \
+    ```bash
+    # Preview changes only (uses the copy from /opt/perfsonar-tp/tools_scripts)
+    /opt/perfsonar-tp/tools_scripts/perfSONAR-update-lsregistration.sh update \
+        --dry-run --site-name "Acme Co." --project WLCG \
+        --admin-email admin@example.org --admin-name "pS Admin"
 
-    --admin-email admin@example.org --admin-name "pS Admin"
+    # Restore previously saved settings from the Prerequisites extract (if you saved a restore script earlier)
+    bash /root/restore-lsreg.sh
 
-# Restore previously saved settings from the Prerequisites extract (if you saved a restore script earlier)
-bash /root/restore-lsreg.sh
-
-
-# Apply new settings and restart the daemon inside the container
-/opt/perfsonar-tp/tools_scripts/perfSONAR-update-lsregistration.sh create \
-    --site-name "Acme Co." --domain example.org --project WLCG --project OSG \
-    --city Berkeley --region CA --country US --zip 94720 \
-    --latitude 37.5 --longitude -121.7469 \
-
-    --admin-name "pS Admin" --admin-email admin@example.org
-
-```
+    # Apply new settings and restart the daemon inside the container
+    /opt/perfsonar-tp/tools_scripts/perfSONAR-update-lsregistration.sh create \
+        --site-name "Acme Co." --domain example.org --project WLCG --project OSG \
+        --city Berkeley --region CA --country US --zip 94720 \
+        --latitude 37.5 --longitude -121.7469 \
+        --admin-name "pS Admin" --admin-email admin@example.org
+    ```
 
 1. **Automatic image updates and safe restarts**
 
@@ -1002,117 +906,101 @@ bash /root/restore-lsreg.sh
     ??? info "Auto-update for compose-managed containers"
         
         Since these containers are managed by `podman-compose`, we use a different approach than systemd-managed containers.
-        Create a simple script and systemd timer to periodically pull new images and restart containers if updates are
+        Create a simple script and systemd timer to periodically pull new images and restart containers if updates are available.
         
-        available.
-        
-1. Create an update script:
+        1. Create an update script:
 
-```bash
-    cat > /usr/local/bin/perfsonar-auto-update.sh << 'EOF'
-    #!/bin/bash
+            ```bash
+            cat > /usr/local/bin/perfsonar-auto-update.sh << 'EOF'
+            #!/bin/bash
+            # perfsonar-auto-update.sh - Check for and apply container image updates
+            set -e
 
-    # perfsonar-auto-update.sh - Check for and apply container image updates
+            COMPOSE_DIR="/opt/perfsonar-tp"
+            LOGFILE="/var/log/perfsonar-auto-update.log"
 
-    set -e
+            log() {
+                echo "$(date -Iseconds) $*" | tee -a "$LOGFILE"
+            }
 
-    COMPOSE_DIR="/opt/perfsonar-tp"
-    LOGFILE="/var/log/perfsonar-auto-update.log"
+            cd "$COMPOSE_DIR"
 
-    log() {
-        echo "$(date -Iseconds) $*" | tee -a "$LOGFILE"
-    }
+            log "Checking for image updates..."
 
-    cd "$COMPOSE_DIR"
+            # Pull latest images
+            if podman-compose pull 2>&1 | tee -a "$LOGFILE" | grep -q "Downloaded newer image"; then
+                log "New images found - recreating containers..."
+                podman-compose up -d
+                log "Containers updated successfully"
+            else
+                log "No updates available"
+            fi
+            EOF
 
-    log "Checking for image updates..."
+            chmod +x /usr/local/bin/perfsonar-auto-update.sh
+            ```
 
-    # Pull latest images
+        1. Create a systemd service:
 
-    if podman-compose pull 2>&1 | tee -a "$LOGFILE" | grep -q "Downloaded newer image"; then
-        log "New images found - recreating containers..."
-        podman-compose up -d
-        log "Containers updated successfully"
-    else
-        log "No updates available"
-    fi
-    EOF
+            ```bash
 
-    chmod +x /usr/local/bin/perfsonar-auto-update.sh
+            cat > /etc/systemd/system/perfsonar-auto-update.service << 'EOF'
+            [Unit]
+            Description=perfSONAR Container Auto-Update
+            After=network-online.target
 
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/local/bin/perfsonar-auto-update.sh
 
-```
+            [Install]
+            WantedBy=multi-user.target
+            EOF
+            ```
 
-1. Create a systemd service:
+        1. Create a systemd timer (runs daily at 3 AM):
 
-```bash
+            ```bash
+            cat > /etc/systemd/system/perfsonar-auto-update.timer << 'EOF'
 
-    cat > /etc/systemd/system/perfsonar-auto-update.service << 'EOF'
-    [Unit]
-    Description=perfSONAR Container Auto-Update
-    After=network-online.target
+            [Unit]
+            Description=perfSONAR Container Auto-Update Timer
 
-    [Service]
-    Type=oneshot
-    ExecStart=/usr/local/bin/perfsonar-auto-update.sh
+            [Timer]
+            OnCalendar=daily
+            RandomizedDelaySec=1h
+            Persistent=true
 
-    [Install]
-    WantedBy=multi-user.target
-    EOF
+            [Install]
+            WantedBy=timers.target
+            EOF
+            ```
 
-```
+        1. Enable and start the timer:
 
-1. Create a systemd timer (runs daily at 3 AM):
+            ```bash
+            systemctl daemon-reload
+            systemctl enable --now perfsonar-auto-update.timer
+            ```
 
-```bash
-    cat > /etc/systemd/system/perfsonar-auto-update.timer << 'EOF'
+        1. Verify the timer is active:
 
-    [Unit]
-    Description=perfSONAR Container Auto-Update Timer
+            ```bash
+            systemctl list-timers perfsonar-auto-update.timer
+            ```
 
-    [Timer]
+        1. Test manually (optional):
 
-    OnCalendar=daily
-    RandomizedDelaySec=1h
-    Persistent=true
+            ```bash
+            systemctl start perfsonar-auto-update.service
+            journalctl -u perfsonar-auto-update.service -n 50
+            ```
 
-    [Install]
+        1. Monitor the update log:
 
-    WantedBy=timers.target
-    EOF
-
-```
-
-1. Enable and start the timer:
-
-```bash
-    systemctl daemon-reload
-    systemctl enable --now perfsonar-auto-update.timer
-
-```
-
-1. Verify the timer is active:
-
-```bash
-systemctl list-timers perfsonar-auto-update.timer
-
-```
-
-1. Test manually (optional):
-
-```bash
-
-systemctl start perfsonar-auto-update.service
-journalctl -u perfsonar-auto-update.service -n 50
-
-```
-
-1. Monitor the update log:
-
-```bash
-tail -f /var/log/perfsonar-auto-update.log
-
-```
+            ```bash
+            tail -f /var/log/perfsonar-auto-update.log
+            ```
 
 This approach ensures containers are updated only when new images are available, minimizing unnecessary restarts while
 keeping your deployment current.
@@ -1127,17 +1015,16 @@ Perform these checks before handing the host over to operations:
 
     ??? info "Verify Podman runtime and containers"
         
-```bash
-# Check Podman service is available
-systemctl status podman
+        ```bash
+        # Check Podman service is available
+        systemctl status podman
 
-# Verify containers are managed by compose
-cd /opt/perfsonar-tp && podman-compose ps
+        # Verify containers are managed by compose
+        cd /opt/perfsonar-tp && podman-compose ps
 
-# Alternative: check containers directly
-podman ps --filter name=perfsonar
-
-```
+        # Alternative: check containers directly
+        podman ps --filter name=perfsonar
+        ```
 
     Ensure Podman is active and containers are running.
 
@@ -1145,68 +1032,61 @@ podman ps --filter name=perfsonar
 
     ??? info "Check container status and logs"
         
-```bash
-# Check all containers are running and healthy
-podman ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+        ```bash
+        # Check all containers are running and healthy
+        podman ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 
-# Check perfsonar-testpoint logs for errors
-podman logs perfsonar-testpoint --tail 50
+        # Check perfsonar-testpoint logs for errors
+        podman logs perfsonar-testpoint --tail 50
 
-# If using Let's Encrypt, check certbot logs
+        # If using Let's Encrypt, check certbot logs
+        podman logs certbot --tail 20 2>/dev/null || echo "Certbot container not present (testpoint-only mode)"
 
-podman logs certbot --tail 20 2>/dev/null || echo "Certbot container not present (testpoint-only mode)"
-
-# Verify services inside container are running
-podman exec perfsonar-testpoint systemctl status apache2 psconfig-pscheduler-agent --no-pager
-
-```
+        # Verify services inside container are running
+        podman exec perfsonar-testpoint systemctl status apache2 psconfig-pscheduler-agent --no-pager
+        ```
 
 1. **Network path validation:**
 
     ??? info "Test network connectivity and routing"
         
         Test throughput to a remote testpoint (run from inside the container):
-        
-```bash
-podman exec -it perfsonar-testpoint pscheduler task throughput --dest <remote-testpoint>
-
-```
+        ```bash
+        podman exec -it perfsonar-testpoint pscheduler task throughput --dest <remote-testpoint>
+        ```
         
         Check routing from the host:
+        ```bash
+        tracepath -n <remote-testpoint>
+        ip route get <remote-testpoint-ip>
+        ```
         
-```bash
-tracepath -n <remote-testpoint>
-ip route get <remote-testpoint-ip>
-
-```
-        
-            Confirm traffic uses the intended policy-based routes (check `ip route get <dest>`).
+        Confirm traffic uses the intended policy-based routes (check `ip route get <dest>`).
         
 1. **Security posture:**
 
     ??? info "Check firewall, fail2ban, and SELinux"
         
-```bash
-# Check nftables firewall rules
-nft list ruleset | grep perfsonar
+        ```bash
+        # Check nftables firewall rules
+        nft list ruleset | grep perfsonar
 
-# Check fail2ban status (if installed in Step 4)
-if command -v fail2ban-client >/dev/null 2>&1; then
-    fail2ban-client status
-else
-    echo "fail2ban not installed (optional)"
-fi
+        # Check fail2ban status (if installed in Step 4)
+        if command -v fail2ban-client >/dev/null 2>&1; then
+            fail2ban-client status
+        else
+            echo "fail2ban not installed (optional)"
+        fi
 
-# Check for recent SELinux denials
-if command -v ausearch >/dev/null 2>&1; then
-    ausearch --message AVC --just-one
-elif [ -f /var/log/audit/audit.log ]; then
-    grep -i "avc.*denied" /var/log/audit/audit.log | tail -5
-else
-    echo "SELinux audit tools not available"
-fi
-
-```
+        # Check for recent SELinux denials
+        if command -v ausearch >/dev/null 2>&1; then
+            ausearch --message AVC --just-one
+        elif [ -f /var/log/audit/audit.log ]; then
+            grep -i "avc.*denied" /var/log/audit/audit.log | tail -5
+        else
+            echo "SELinux audit tools not available"
+        fi
+        ```
 
     Investigate any SELinux denials or repeated Fail2Ban bans.
 
@@ -1214,28 +1094,24 @@ fi
 
     ??? info "Verify certificate validity"
         
-```bash
-# Check certificate via HTTPS connection
-echo | openssl s_client -connect <SERVER_FQDN>:443 -servername <SERVER_FQDN> 2>/dev/null | openssl x509 -noout -dates -issuer
+        ```bash
+        # Check certificate via HTTPS connection
+        echo | openssl s_client -connect <SERVER_FQDN>:443 -servername <SERVER_FQDN> 2>/dev/null | openssl x509 -noout -dates -issuer
 
+        # Alternative: Check certificate files directly
+        sudo openssl x509 -in /etc/letsencrypt/live/<SERVER_FQDN>/cert.pem -noout -dates -issuer
+        ```
 
-# Alternative: Check certificate files directly
-sudo openssl x509 -in /etc/letsencrypt/live/<SERVER_FQDN>/cert.pem -noout -dates -issuer
-
-```
-
-Ensure the issuer is Let's Encrypt and the validity period is acceptable. This check only applies if you configured
-Let's Encrypt in Step 3.
+    Ensure the issuer is Let's Encrypt and the validity period is acceptable. This check only applies if you configured Let's Encrypt in Step 3.
 
 1. **Reporting:**
 
-??? info "Run perfSONAR diagnostic reports" Run the perfSONAR troubleshoot command from inside the container and send
-    outputs to operations:
-    
-```bash
-podman exec -it perfsonar-testpoint pscheduler troubleshoot
-    
-```
+    ??? info "Run perfSONAR diagnostic reports"
+        
+        Run the perfSONAR troubleshoot command from inside the container and send outputs to operations:
+        ```bash
+        podman exec -it perfsonar-testpoint pscheduler troubleshoot
+        ```
     
 ---
 
@@ -1280,13 +1156,10 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
 
     **Common causes:**
 
-- Missing entrypoint wrapper: Ensure `/opt/perfsonar-tp/tools_scripts/testpoint-entrypoint-wrapper.sh` exists
-
-- SELinux denials: Check `ausearch -m avc -ts recent` and consider temporarily setting to permissive mode for testing
-
-- Incorrect bind-mount paths: Verify all host directories exist and have correct permissions
-
-- Cgroup issues: Ensure `cgroupns: private` is set and no manual cgroup bind-mounts exist
+    - Missing entrypoint wrapper: Ensure `/opt/perfsonar-tp/tools_scripts/testpoint-entrypoint-wrapper.sh` exists
+    - SELinux denials: Check `ausearch -m avc -ts recent` and consider temporarily setting to permissive mode for testing
+    - Incorrect bind-mount paths: Verify all host directories exist and have correct permissions
+    - Cgroup issues: Ensure `cgroupns: private` is set and no manual cgroup bind-mounts exist
 
 ??? failure "Container won't start or exits immediately"
     
@@ -1309,13 +1182,10 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
 
     **Common causes:**
 
-- Missing entrypoint wrapper: Ensure `/opt/perfsonar-tp/tools_scripts/testpoint-entrypoint-wrapper.sh` exists
-
-- SELinux denials: Check `ausearch -m avc -ts recent` and consider temporarily setting to permissive mode for testing
-
-- Incorrect bind-mount paths: Verify all host directories exist and have correct permissions
-
-- Cgroup issues: Ensure `cgroupns: private` is set and no manual cgroup bind-mounts exist
+    - Missing entrypoint wrapper: Ensure `/opt/perfsonar-tp/tools_scripts/testpoint-entrypoint-wrapper.sh` exists
+    - SELinux denials: Check `ausearch -m avc -ts recent` and consider temporarily setting to permissive mode for testing
+    - Incorrect bind-mount paths: Verify all host directories exist and have correct permissions
+    - Cgroup issues: Ensure `cgroupns: private` is set and no manual cgroup bind-mounts exist
 
 ??? failure "Container crashes after reboot with exit code 255"
     
@@ -1335,12 +1205,10 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     systemctl status perfsonar-testpoint.service
 
     # View recent container logs
-
     podman logs perfsonar-testpoint --tail 100
 
     # Check if using compose-based service (BAD)
     grep -A5 "ExecStart" /etc/systemd/system/perfsonar-testpoint.service
-
     ```
 
     **Solution:**
@@ -1368,26 +1236,20 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     systemctl enable --now perfsonar-testpoint.service
 
     # If using certbot:
-
     systemctl enable --now perfsonar-certbot.service
 
     # Verify containers are running
     podman ps
     curl -kI https://127.0.0.1/
-
     ```
 
     **Verification:**
 
     After installing the new units, the testpoint should:
-
-- Start successfully on boot
-
-- Run systemd properly inside the container
-
-- Maintain state across reboots
-
-- Show "Up" status in `podman ps` (not "Exited" or crash-looping)
+    - Start successfully on boot
+    - Run systemd properly inside the container
+    - Maintain state across reboots
+    - Show "Up" status in `podman ps` (not "Exited" or crash-looping)
 
 ??? failure "Certbot service fails with 'Unable to open config file' error"
     
@@ -1411,23 +1273,19 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
 
     # Verify service file configuration
     grep -A5 "ExecStart" /etc/systemd/system/perfsonar-certbot.service
-
     ```
 
     **Solution:**
 
     The certbot service needs two flags:
-
-- `--systemd=always` for proper systemd integration and reboot persistence
-
-- `--entrypoint=/bin/sh` to override the built-in entrypoint
+    - `--systemd=always` for proper systemd integration and reboot persistence
+    - `--entrypoint=/bin/sh` to override the built-in entrypoint
 
     Re-run the installation script to get the fixed version:
 
     ```bash
     # Stop current service
     systemctl stop perfsonar-certbot.service
-
 
     # Download and install updated systemd units
     curl -fsSL \
@@ -1445,11 +1303,9 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     # Verify it's running
     systemctl status perfsonar-certbot.service
     podman ps | grep certbot
-
     ```
 
-**Expected result:** The certbot container should be running (not exiting) and the service should be in "active
-(running)" state.
+    **Expected result:** The certbot container should be running (not exiting) and the service should be in "active (running)" state.
 
 ??? failure "SELinux denials blocking container operations"
     
@@ -1473,10 +1329,8 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     **Solutions:**
 
     - Verify volume labels are correct (`:Z` for exclusive, `:z` for shared)
-
-- Recreate containers to reapply SELinux labels: `podman-compose down && podman-compose up -d`
-
-- If persistent issues, consider creating custom SELinux policy or running in permissive mode
+    - Recreate containers to reapply SELinux labels: `podman-compose down && podman-compose up -d`
+    - If persistent issues, consider creating custom SELinux policy or running in permissive mode
 
 ### Networking Issues
 
@@ -1508,12 +1362,9 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     **Solutions:**
 
     - Verify `/etc/perfSONAR-multi-nic-config.conf` has correct IPs and gateways
-
-- Reapply configuration: `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --yes`
-
-- Reboot if rules are not being applied correctly
-
-- Check for conflicting NetworkManager or systemd-networkd rules
+    - Reapply configuration: `/opt/perfsonar-tp/tools_scripts/perfSONAR-pbr-nm.sh --yes`
+    - Reboot if rules are not being applied correctly
+    - Check for conflicting NetworkManager or systemd-networkd rules
 
 ??? failure "DNS resolution failing for test endpoints"
     
@@ -1537,10 +1388,8 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     **Solutions:**
 
     - Ensure DNS servers are correctly configured on host
-
-- Fix missing PTR records in DNS zones
-
-- Verify forward A/AAAA records match reverse PTR records
+    - Fix missing PTR records in DNS zones
+    - Verify forward A/AAAA records match reverse PTR records
 
 ### Certificate Issues
 
@@ -1572,13 +1421,10 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
 
     **Common causes:**
 
-- Port 80 blocked by firewall: Add with `perfSONAR-install-nftables.sh --ports=80,443`
-
-- Apache listening on port 80: Verify testpoint-entrypoint-wrapper.sh patched Apache correctly
-
-- DNS not propagated: Wait for DNS changes to propagate globally
-
-- Rate limiting: Let's Encrypt has rate limits; wait if you've hit them
+    - Port 80 blocked by firewall: Add with `perfSONAR-install-nftables.sh --ports=80,443`
+    - Apache listening on port 80: Verify testpoint-entrypoint-wrapper.sh patched Apache correctly
+    - DNS not propagated: Wait for DNS changes to propagate globally
+    - Rate limiting: Let's Encrypt has rate limits; wait if you've hit them
 
 ??? failure "Certificate not loaded after renewal"
     
@@ -1604,18 +1450,13 @@ podman exec -it perfsonar-testpoint pscheduler troubleshoot
     **Solutions:**
 
     - Verify deploy hook script exists and is executable: `/opt/perfsonar-tp/tools_scripts/certbot-deploy-hook.sh`
+    - Ensure deploy hook is mounted in container at: `/etc/letsencrypt/renewal-hooks/deploy/certbot-deploy-hook.sh`
+    - Verify Podman socket is mounted in certbot container: `/run/podman/podman.sock`
+    - Check deploy hook logs: `journalctl -u perfsonar-certbot.service | grep deploy`
+    - Manually restart testpoint after renewals if deploy hook fails: `podman restart perfsonar-testpoint`
 
-- Ensure deploy hook is mounted in container at: `/etc/letsencrypt/renewal-hooks/deploy/certbot-deploy-hook.sh`
-
-- Verify Podman socket is mounted in certbot container: `/run/podman/podman.sock`
-
-- Check deploy hook logs: `journalctl -u perfsonar-certbot.service | grep deploy`
-
-- Manually restart testpoint after renewals if deploy hook fails: `podman restart perfsonar-testpoint`
-
-**Note:** Certbot automatically executes scripts in `/etc/letsencrypt/renewal-hooks/deploy/` when certificates are
-renewed. Do not use `--deploy-hook` parameter with full paths ending in `.sh` as certbot will append `-hook` to the
-filename.
+    **Note:** Certbot automatically executes scripts in `/etc/letsencrypt/renewal-hooks/deploy/` when certificates are
+    renewed. Do not use `--deploy-hook` parameter with full paths ending in `.sh` as certbot will append `-hook` to the filename.
 
 ### perfSONAR Service Issues
 
@@ -1640,12 +1481,9 @@ filename.
     **Solutions:**
 
     - Restart services inside container: `podman exec perfsonar-testpoint systemctl restart apache2`
-
-- Check Apache SSL configuration was patched correctly
-
-- Verify certificates are in place: `ls -la /etc/letsencrypt/live/`
-
-- Restart container: `podman restart perfsonar-testpoint`
+    - Check Apache SSL configuration was patched correctly
+    - Verify certificates are in place: `ls -la /etc/letsencrypt/live/`
+    - Restart container: `podman restart perfsonar-testpoint`
 
 ### Auto-Update Issues
 
@@ -1674,12 +1512,9 @@ filename.
     **Solutions:**
 
     - Enable timer if not active: `systemctl enable --now perfsonar-auto-update.timer`
-
-- Verify script exists and is executable: `ls -la /usr/local/bin/perfsonar-auto-update.sh`
-
-- Check podman-compose is installed and working
-
-- Review script for errors and update if needed
+    - Verify script exists and is executable: `ls -la /usr/local/bin/perfsonar-auto-update.sh`
+    - Check podman-compose is installed and working
+    - Review script for errors and update if needed
 
 ### General Debugging Tips
 
@@ -1714,7 +1549,6 @@ filename.
 
     # Check nftables rules
     nft list ruleset
-
     ```
 
     **Logs:**
@@ -1728,7 +1562,6 @@ filename.
 
     # Follow logs in real-time
     podman logs -f perfsonar-testpoint
-
     ```
 
 ---


### PR DESCRIPTION
Fixes that restore context/nesting lost by programmatic edits: 1) restore correct indentation for code fences and code blocks 2) re-dedent admonition content 3) correct and add anchor link(s). This PR contains only doc fixes to  and a smalldoc formatting changes. Tested: mkdocs build + site backtick checker returns OK locally.