### PR TITLE
Consolidate fasterdata documentation

### DIFF
--- a/docs/host-network-tuning.md
+++ b/docs/host-network-tuning.md
@@ -1,17 +1,21 @@
 # Host and Network Tuning (EL9)
 
-This guide distills ESnet Fasterdata recommendations for high-throughput hosts (perfSONAR/DTN-style) on Enterprise Linux
+!!! note "Documentation Moved"
+    This page has been consolidated. Please see the canonical documentation:
+    
+    **[Fasterdata Host & Network Tuning Guide](perfsonar/tools_scripts/fasterdata-tuning.md)**
 
-1. Primary sources:
+---
 
-- <https://fasterdata.es.net/host-tuning/>
+## Quick Reference
 
-- <https://fasterdata.es.net/network-tuning/>
+For ESnet Fasterdata recommendations and the `fasterdata-tuning.sh` script, see:
 
-- <https://fasterdata.es.net/DTN/>
+- **[Fasterdata Tuning Script Documentation](perfsonar/tools_scripts/fasterdata-tuning.md)** — Complete guide for audit and apply modes
+- **[ESnet Fasterdata Host Tuning](https://fasterdata.es.net/host-tuning/)** — Upstream recommendations
+- **[ESnet Network Tuning](https://fasterdata.es.net/network-tuning/)** — Network-level guidance
+- **[ESnet DTN Tuning](https://fasterdata.es.net/DTN/)** — Data Transfer Node specific tuning
 
-Use the provided audit/apply script to check your host against these recommendations and optionally enforce them. Read
-the cautions before applying.
 
 ## What this covers
 
@@ -365,6 +369,9 @@ To manually update this service, re-run the script with `--mode apply` to regene
 - Sysctl settings persist via `/etc/sysctl.d/90-fasterdata.conf`
 
 - NIC ethtool changes do not persist by default; consider:
+
+</details>
+
 
 - running this script from a boot-time systemd unit, or
 

--- a/docs/personas/quick-deploy/landing.md
+++ b/docs/personas/quick-deploy/landing.md
@@ -45,7 +45,7 @@ Get perfSONAR running on OSG/WLCG in **1-2 hours** with guided installation.
 
 Optimize kernel and NIC settings for network throughput:
 
-- **[Fasterdata Tuning](../../network-troubleshooting.md)** — ESnet recommendations for high-performance hosts
+- **[Fasterdata Tuning](../../perfsonar/tools_scripts/fasterdata-tuning.md)** — ESnet recommendations for high-performance hosts
 - Tool: `fasterdata-tuning.sh` (audit and apply modes, ~15 minutes)
 
 ---

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -237,7 +237,7 @@ tp/docker-compose.yml` | Container definition | | `/opt/perfsonar-tp/tools_scrip
 ## Documentation Links
 
 | Topic | Link | |-------|------| | **Installation** | [Quick Deploy Guide](personas/quick-deploy/landing.md) | |
-**Troubleshooting** | [Troubleshooter Guide](personas/troubleshoot/landing.md) | | **Host Tuning** | [Fasterdata
+**Troubleshooting** | [Troubleshooter Guide](personas/troubleshoot/landing.md) | | **Host Tuning** | [Fasterdata Tuning](perfsonar/tools_scripts/fasterdata-tuning.md)
 Tuning](host-network-tuning.md) | | **Architecture** | [System Overview](personas/research/landing.md) | | **Tools** |
 [Tools & Scripts](perfsonar/tools_scripts/README.md) | | **FAQ** | [perfSONAR FAQ](perfsonar/faq.md) | | **Official
 Docs** | [docs.perfsonar.net](https://docs.perfsonar.net/) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ nav:
     - 'Legacy Installation (Archive)': 'perfsonar/installation.md'
     - 'FAQ': 'perfsonar/faq.md'
   - Host Tuning:
-    - 'Fasterdata Host Tuning': 'host-network-tuning.md'
+    - 'Fasterdata Host Tuning': 'perfsonar/tools_scripts/fasterdata-tuning.md'
     - 'Multiple NIC Guidance': 'perfsonar/multiple-nic-guidance.md'
   - Troubleshooting:
     - 'Triage Checklist': 'personas/troubleshoot/triage-checklist.md'


### PR DESCRIPTION
- Redirect `docs/host-network-tuning.md` to canonical `perfsonar/tools_scripts/fasterdata-tuning.md`
- Update all references to point to canonical fasterdata-tuning.md page
- Update mkdocs.yml navigation to reference canonical page
- Keep ESnet fasterdata.es.net upstream links (as requested)
- Eliminates duplicate/redundant fasterdata content

This consolidation ensures users always find the most up-to-date fasterdata tuning documentation in a single location, while preserving ESnet upstream references.