### PR TITLE
fix: change certbot :Z volume mounts to :z to prevent SELinux MCS lockout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 All notable changes to this repository will be documented in this file.
 
+## [1.5.1] - 2026-02-26
+
+### Fixed
+
+- **`docker-compose.testpoint-le.yml` and `docker-compose.testpoint-le-auto.yml`**: Changed the `certbot` service volume mounts for `/etc/letsencrypt` and `/var/www/html` from `:Z` (private SELinux MCS relabeling) to `:z` (shared). The `:Z` flag stamped the certbot container's MCS categories onto those host directories on every container recreation. `/etc/letsencrypt:Z` caused Apache to fail (`SSLCertificateFile does not exist`, connection refused on port 443). `/var/www/html:Z` caused Apache to return 403 on all endpoints (`Permission denied: search permissions are missing on a component of the path`). Immediate recovery on affected hosts: `chcon -R -t container_file_t -l s0 /etc/letsencrypt /var/www/html`, then `podman exec perfsonar-testpoint systemctl start apache2`.
+
 ## [1.5.0] - 2026-02-26
 
 ### Added

--- a/docs/perfsonar/tools_scripts/docker-compose.testpoint-le-auto.yml
+++ b/docs/perfsonar/tools_scripts/docker-compose.testpoint-le-auto.yml
@@ -64,8 +64,8 @@ services:
     # API to restart the testpoint container after renewal.
     volumes:
       - /run/podman/podman.sock:/run/podman/podman.sock:ro
-      - /var/www/html:/var/www/html:Z
-      - /etc/letsencrypt:/etc/letsencrypt:Z
+      - /var/www/html:/var/www/html:z
+      - /etc/letsencrypt:/etc/letsencrypt:z
       # Mount the deploy hook script into the container
       - ./tools_scripts/certbot-deploy-hook.sh:/etc/letsencrypt/renewal-hooks/deploy/certbot-deploy-hook.sh:ro
     healthcheck:

--- a/docs/perfsonar/tools_scripts/docker-compose.testpoint-le.yml
+++ b/docs/perfsonar/tools_scripts/docker-compose.testpoint-le.yml
@@ -56,8 +56,8 @@ services:
     # API to restart the testpoint container after renewal.
     volumes:
       - /run/podman/podman.sock:/run/podman/podman.sock:ro
-      - /var/www/html:/var/www/html:Z
-      - /etc/letsencrypt:/etc/letsencrypt:Z
+      - /var/www/html:/var/www/html:z
+      - /etc/letsencrypt:/etc/letsencrypt:z
       # Mount the deploy hook script into the container
       - ./tools_scripts/certbot-deploy-hook.sh:/etc/letsencrypt/renewal-hooks/deploy/certbot-deploy-hook.sh:ro
     healthcheck:


### PR DESCRIPTION
## Problem

After running `update-perfsonar-deployment.sh` (which recreates containers), two failures occur:

**1. Apache fails to start** — `/etc/letsencrypt:Z` stamps certbot's MCS onto the cert directory:
```
SSLCertificateFile: file '/etc/letsencrypt/live/<host>/fullchain.pem' does not exist or is empty
```
→ connection refused (HTTP 000) on port 443

**2. Apache returns 403 on all endpoints** — `/var/www/html:Z` stamps certbot's MCS onto the web root:
```
Permission denied: access to /perfsonar_host_exporter/ denied (filesystem path '/var/www/html/perfsonar')
because search permissions are missing on a component of the path
```
→ both `node_exporter` and `perfsonar_host_exporter` return HTTP 403

## Root Cause

The `certbot` service mounted `/etc/letsencrypt` and `/var/www/html` with `:Z` (private MCS relabeling). Each time the certbot container is recreated it gets new random MCS categories and `:Z` re-stamps those onto the host directories. The `perfsonar-testpoint` container mounts the same paths with `:z` (shared) but SELinux denies access because the files now carry certbot's private MCS labels.

## Fix

Change the certbot volume mounts from `:Z` → `:z` (shared `container_file_t:s0` without MCS restriction) in both:
- `docker-compose.testpoint-le.yml`
- `docker-compose.testpoint-le-auto.yml`

## Immediate Recovery (affected hosts)

```bash
chcon -R -t container_file_t -l s0 /etc/letsencrypt /var/www/html
podman exec perfsonar-testpoint systemctl start apache2
```